### PR TITLE
[OMCT-51] 회원 삭제 기능 구현

### DIFF
--- a/src/main/java/com/programmers/bucketback/domains/common/BaseEntity.java
+++ b/src/main/java/com/programmers/bucketback/domains/common/BaseEntity.java
@@ -6,8 +6,10 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
 @Getter
@@ -16,9 +18,13 @@ import lombok.Getter;
 public abstract class BaseEntity {
 
 	@CreatedDate
+	@NotNull
+	@Column(name = "create_at", columnDefinition = "datetime(6)", updatable = false)
 	private LocalDateTime createdAt;
 
 	@LastModifiedDate
+	@NotNull
+	@Column(name = "modify_at", columnDefinition = "datetime(6)")
 	private LocalDateTime modifiedAt;
 
 }

--- a/src/main/java/com/programmers/bucketback/domains/common/BaseEntity.java
+++ b/src/main/java/com/programmers/bucketback/domains/common/BaseEntity.java
@@ -19,12 +19,12 @@ public abstract class BaseEntity {
 
 	@CreatedDate
 	@NotNull
-	@Column(name = "create_at", columnDefinition = "datetime(6)", updatable = false)
+	@Column(name = "created_at", columnDefinition = "datetime(6)", updatable = false)
 	private LocalDateTime createdAt;
 
 	@LastModifiedDate
 	@NotNull
-	@Column(name = "modify_at", columnDefinition = "datetime(6)")
+	@Column(name = "modified_at", columnDefinition = "datetime(6)")
 	private LocalDateTime modifiedAt;
 
 }

--- a/src/main/java/com/programmers/bucketback/domains/common/MemberUtils.java
+++ b/src/main/java/com/programmers/bucketback/domains/common/MemberUtils.java
@@ -1,0 +1,14 @@
+package com.programmers.bucketback.domains.common;
+
+import com.programmers.bucketback.global.config.security.SecurityUtils;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class MemberUtils {
+
+	public static Long getCurrentMemberId() {
+		return SecurityUtils.getCurrentMemberId();
+	}
+}

--- a/src/main/java/com/programmers/bucketback/domains/member/api/MemberController.java
+++ b/src/main/java/com/programmers/bucketback/domains/member/api/MemberController.java
@@ -32,7 +32,7 @@ public class MemberController {
 
 	@PostMapping("/login")
 	public ResponseEntity<MemberLoginResponse> login(@Valid @RequestBody final MemberLoginRequest request) {
-		LoginMemberServiceResponse response = memberService.login(request.toLoginMemberServiceRequest());
+		final LoginMemberServiceResponse response = memberService.login(request.toLoginMemberServiceRequest());
 
 		return ResponseEntity.ok(response.toMemberLoginResponse());
 	}

--- a/src/main/java/com/programmers/bucketback/domains/member/api/MemberController.java
+++ b/src/main/java/com/programmers/bucketback/domains/member/api/MemberController.java
@@ -1,14 +1,15 @@
 package com.programmers.bucketback.domains.member.api;
 
-import com.programmers.bucketback.domains.member.api.dto.request.MemberLoginRequest;
-import com.programmers.bucketback.domains.member.api.dto.response.MemberLoginResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.programmers.bucketback.domains.member.api.dto.request.MemberLoginRequest;
 import com.programmers.bucketback.domains.member.api.dto.request.MemberSignupRequest;
+import com.programmers.bucketback.domains.member.api.dto.response.MemberLoginResponse;
 import com.programmers.bucketback.domains.member.application.MemberService;
 import com.programmers.bucketback.domains.member.application.dto.response.LoginMemberServiceResponse;
 
@@ -34,5 +35,12 @@ public class MemberController {
 		LoginMemberServiceResponse response = memberService.login(request.toLoginMemberServiceRequest());
 
 		return ResponseEntity.ok(response.toMemberLoginResponse());
+	}
+
+	@DeleteMapping("/delete")
+	public ResponseEntity<Void> deleteMember() {
+		memberService.deleteMember();
+
+		return ResponseEntity.ok().build();
 	}
 }

--- a/src/main/java/com/programmers/bucketback/domains/member/application/MemberService.java
+++ b/src/main/java/com/programmers/bucketback/domains/member/application/MemberService.java
@@ -39,12 +39,12 @@ public class MemberService {
 	}
 
 	 public LoginMemberServiceResponse login(LoginMemberServiceRequest request) {
-		 UsernamePasswordAuthenticationToken authenticationToken =
-				 new UsernamePasswordAuthenticationToken(request.email(), request.password());
-		 authenticationManager.authenticate(authenticationToken);
+		 Member member = memberRepository.findByEmail(request.email())
+			 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
 
-	 	Member member = memberRepository.findByEmail(request.email())
-	 		.orElseThrow(() -> new EntityNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
+		 UsernamePasswordAuthenticationToken authenticationToken =
+				 new UsernamePasswordAuthenticationToken(member.getId(), request.password());
+		 authenticationManager.authenticate(authenticationToken);
 
 	 	String jwtToken = jwtService.generateToken(new MemberSecurity(member));
 

--- a/src/main/java/com/programmers/bucketback/domains/member/application/MemberService.java
+++ b/src/main/java/com/programmers/bucketback/domains/member/application/MemberService.java
@@ -4,7 +4,9 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import com.programmers.bucketback.domains.common.MemberUtils;
 import com.programmers.bucketback.domains.member.application.dto.request.LoginMemberServiceRequest;
 import com.programmers.bucketback.domains.member.application.dto.request.SignupMemberServiceRequest;
 import com.programmers.bucketback.domains.member.application.dto.response.LoginMemberServiceResponse;
@@ -50,4 +52,14 @@ public class MemberService {
 
 	 	return new LoginMemberServiceResponse(member.getNickname(), jwtToken);
 	 }
+
+	@Transactional
+	public void deleteMember() {
+		Long memberId = MemberUtils.getCurrentMemberId();
+
+		Member member = memberRepository.findById(memberId)
+			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
+
+		member.delete();
+	}
 }

--- a/src/main/java/com/programmers/bucketback/domains/member/application/MemberService.java
+++ b/src/main/java/com/programmers/bucketback/domains/member/application/MemberService.java
@@ -40,18 +40,18 @@ public class MemberService {
 		memberRepository.save(member);
 	}
 
-	 public LoginMemberServiceResponse login(LoginMemberServiceRequest request) {
-		 Member member = memberRepository.findByEmail(request.email())
-			 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
+	public LoginMemberServiceResponse login(final LoginMemberServiceRequest request) {
+		Member member = memberRepository.findByEmail(request.email())
+			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
 
-		 UsernamePasswordAuthenticationToken authenticationToken =
-				 new UsernamePasswordAuthenticationToken(member.getId(), request.password());
-		 authenticationManager.authenticate(authenticationToken);
+		UsernamePasswordAuthenticationToken authenticationToken =
+			new UsernamePasswordAuthenticationToken(member.getId(), request.password());
+		authenticationManager.authenticate(authenticationToken);
 
-	 	String jwtToken = jwtService.generateToken(new MemberSecurity(member));
+		String jwtToken = jwtService.generateToken(new MemberSecurity(member));
 
-	 	return new LoginMemberServiceResponse(member.getNickname(), jwtToken);
-	 }
+		return new LoginMemberServiceResponse(member.getNickname(), jwtToken);
+	}
 
 	@Transactional
 	public void deleteMember() {

--- a/src/main/java/com/programmers/bucketback/domains/member/application/MemberService.java
+++ b/src/main/java/com/programmers/bucketback/domains/member/application/MemberService.java
@@ -12,9 +12,11 @@ import com.programmers.bucketback.domains.member.application.dto.request.SignupM
 import com.programmers.bucketback.domains.member.application.dto.response.LoginMemberServiceResponse;
 import com.programmers.bucketback.domains.member.domain.Member;
 import com.programmers.bucketback.domains.member.domain.MemberSecurity;
+import com.programmers.bucketback.domains.member.domain.MemberStatus;
 import com.programmers.bucketback.domains.member.domain.Role;
 import com.programmers.bucketback.domains.member.repository.MemberRepository;
 import com.programmers.bucketback.global.config.security.jwt.JwtService;
+import com.programmers.bucketback.global.error.exception.BusinessException;
 import com.programmers.bucketback.global.error.exception.EntityNotFoundException;
 import com.programmers.bucketback.global.error.exception.ErrorCode;
 
@@ -43,6 +45,10 @@ public class MemberService {
 	public LoginMemberServiceResponse login(final LoginMemberServiceRequest request) {
 		Member member = memberRepository.findByEmail(request.email())
 			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
+
+		if (member.getStatus() == MemberStatus.DELETED) {
+			throw new BusinessException(ErrorCode.MEMBER_DELETED);
+		}
 
 		UsernamePasswordAuthenticationToken authenticationToken =
 			new UsernamePasswordAuthenticationToken(member.getId(), request.password());

--- a/src/main/java/com/programmers/bucketback/domains/member/application/MemberService.java
+++ b/src/main/java/com/programmers/bucketback/domains/member/application/MemberService.java
@@ -32,7 +32,7 @@ public class MemberService {
 	private final AuthenticationManager authenticationManager;
 
 	public void signup(final SignupMemberServiceRequest request) {
-		Member member = Member.builder()
+		final Member member = Member.builder()
 			.email(request.email())
 			.password(passwordEncoder.encode(request.password()))
 			.nickname(request.nickname())
@@ -43,27 +43,27 @@ public class MemberService {
 	}
 
 	public LoginMemberServiceResponse login(final LoginMemberServiceRequest request) {
-		Member member = memberRepository.findByEmail(request.email())
+		final Member member = memberRepository.findByEmail(request.email())
 			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
 
 		if (member.getStatus() == MemberStatus.DELETED) {
 			throw new BusinessException(ErrorCode.MEMBER_DELETED);
 		}
 
-		UsernamePasswordAuthenticationToken authenticationToken =
+		final UsernamePasswordAuthenticationToken authenticationToken =
 			new UsernamePasswordAuthenticationToken(member.getId(), request.password());
 		authenticationManager.authenticate(authenticationToken);
 
-		String jwtToken = jwtService.generateToken(new MemberSecurity(member));
+		final String jwtToken = jwtService.generateToken(new MemberSecurity(member));
 
 		return new LoginMemberServiceResponse(member.getNickname(), jwtToken);
 	}
 
 	@Transactional
 	public void deleteMember() {
-		Long memberId = MemberUtils.getCurrentMemberId();
+		final Long memberId = MemberUtils.getCurrentMemberId();
 
-		Member member = memberRepository.findById(memberId)
+		final Member member = memberRepository.findById(memberId)
 			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
 
 		member.delete();

--- a/src/main/java/com/programmers/bucketback/domains/member/application/MemberService.java
+++ b/src/main/java/com/programmers/bucketback/domains/member/application/MemberService.java
@@ -12,7 +12,6 @@ import com.programmers.bucketback.domains.member.application.dto.request.SignupM
 import com.programmers.bucketback.domains.member.application.dto.response.LoginMemberServiceResponse;
 import com.programmers.bucketback.domains.member.domain.Member;
 import com.programmers.bucketback.domains.member.domain.MemberSecurity;
-import com.programmers.bucketback.domains.member.domain.MemberStatus;
 import com.programmers.bucketback.domains.member.domain.Role;
 import com.programmers.bucketback.domains.member.repository.MemberRepository;
 import com.programmers.bucketback.global.config.security.jwt.JwtService;
@@ -46,7 +45,7 @@ public class MemberService {
 		final Member member = memberRepository.findByEmail(request.email())
 			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
 
-		if (member.getStatus() == MemberStatus.DELETED) {
+		if (member.isDeleted()) {
 			throw new BusinessException(ErrorCode.MEMBER_DELETED);
 		}
 

--- a/src/main/java/com/programmers/bucketback/domains/member/domain/Member.java
+++ b/src/main/java/com/programmers/bucketback/domains/member/domain/Member.java
@@ -51,6 +51,11 @@ public class Member extends BaseEntity {
 	@Column(name = "role")
 	private Role role;
 
+	@NotNull
+	@Enumerated(EnumType.STRING)
+	@Column(name = "status")
+	private MemberStatus status;
+
 	@Builder
 	private Member(
 		@NotNull final String email,
@@ -63,5 +68,10 @@ public class Member extends BaseEntity {
 		this.nickname = nickname;
 		this.levelPoint = 0;
 		this.role = role;
+		this.status = MemberStatus.ACTIVE;
+	}
+
+	public void delete() {
+		this.status = MemberStatus.DELETED;
 	}
 }

--- a/src/main/java/com/programmers/bucketback/domains/member/domain/Member.java
+++ b/src/main/java/com/programmers/bucketback/domains/member/domain/Member.java
@@ -74,4 +74,8 @@ public class Member extends BaseEntity {
 	public void delete() {
 		this.status = MemberStatus.DELETED;
 	}
+
+	public boolean isDeleted() {
+		return this.getStatus() == MemberStatus.DELETED;
+	}
 }

--- a/src/main/java/com/programmers/bucketback/domains/member/domain/MemberSecurity.java
+++ b/src/main/java/com/programmers/bucketback/domains/member/domain/MemberSecurity.java
@@ -26,7 +26,7 @@ public class MemberSecurity implements UserDetails {
 
 	@Override
 	public String getUsername() {
-		return member.getEmail();
+		return String.valueOf(member.getId());
 	}
 
 	@Override

--- a/src/main/java/com/programmers/bucketback/domains/member/domain/MemberStatus.java
+++ b/src/main/java/com/programmers/bucketback/domains/member/domain/MemberStatus.java
@@ -1,0 +1,6 @@
+package com.programmers.bucketback.domains.member.domain;
+
+public enum MemberStatus {
+	ACTIVE,
+	DELETED
+}

--- a/src/main/java/com/programmers/bucketback/global/config/security/ApplicationConfiguration.java
+++ b/src/main/java/com/programmers/bucketback/global/config/security/ApplicationConfiguration.java
@@ -26,7 +26,7 @@ public class ApplicationConfiguration {
 	@Bean
 	public UserDetailsService userDetailsService() {
 		return username -> {
-			Member member = memberRepository.findByEmail(username)
+			Member member = memberRepository.findById(Long.valueOf(username))
 				.orElseThrow(() -> new UsernameNotFoundException("User not found."));
 			return new MemberSecurity(member);
 		};

--- a/src/main/java/com/programmers/bucketback/global/config/security/ApplicationConfiguration.java
+++ b/src/main/java/com/programmers/bucketback/global/config/security/ApplicationConfiguration.java
@@ -41,7 +41,7 @@ public class ApplicationConfiguration {
 	}
 
 	@Bean
-	public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+	public AuthenticationManager authenticationManager(final AuthenticationConfiguration configuration) throws Exception {
 		return configuration.getAuthenticationManager();
 	}
 

--- a/src/main/java/com/programmers/bucketback/global/config/security/SecurityConfiguration.java
+++ b/src/main/java/com/programmers/bucketback/global/config/security/SecurityConfiguration.java
@@ -21,7 +21,7 @@ public class SecurityConfiguration {
 	private final AuthenticationProvider authenticationProvider;
 
 	@Bean
-	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+	public SecurityFilterChain securityFilterChain(final HttpSecurity http) throws Exception {
 		http
 			.csrf(AbstractHttpConfigurer::disable)
 			.authorizeHttpRequests(authorize -> authorize

--- a/src/main/java/com/programmers/bucketback/global/config/security/SecurityUtils.java
+++ b/src/main/java/com/programmers/bucketback/global/config/security/SecurityUtils.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class SecurityUtils {
 
-	private static SimpleGrantedAuthority anonymousMember = new SimpleGrantedAuthority("ROLE_ANONYMOUS");
+	private static final SimpleGrantedAuthority anonymousMember = new SimpleGrantedAuthority("ROLE_ANONYMOUS");
 
 	public static Long getCurrentMemberId() {
 		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();

--- a/src/main/java/com/programmers/bucketback/global/config/security/SecurityUtils.java
+++ b/src/main/java/com/programmers/bucketback/global/config/security/SecurityUtils.java
@@ -1,0 +1,30 @@
+package com.programmers.bucketback.global.config.security;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import com.programmers.bucketback.global.error.exception.BusinessException;
+import com.programmers.bucketback.global.error.exception.ErrorCode;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class SecurityUtils {
+
+	private static SimpleGrantedAuthority anonymousMember = new SimpleGrantedAuthority("ROLE_ANONYMOUS");
+
+	public static Long getCurrentMemberId() {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		if (authentication == null) {
+			throw new BusinessException(ErrorCode.SECURITY_CONTEXT_NOT_FOUND);
+		}
+
+		if (!authentication.isAuthenticated() || authentication.getAuthorities().contains(anonymousMember)) {
+			throw new BusinessException(ErrorCode.MEMBER_ANONYMOUS);
+		}
+
+		return Long.valueOf(authentication.getName());
+	}
+}

--- a/src/main/java/com/programmers/bucketback/global/config/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/programmers/bucketback/global/config/security/jwt/JwtAuthenticationFilter.java
@@ -26,9 +26,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 	@Override
 	protected void doFilterInternal(
-		@NonNull HttpServletRequest request,
-		@NonNull HttpServletResponse response,
-		@NonNull FilterChain filterChain
+		@NonNull final HttpServletRequest request,
+		@NonNull final HttpServletResponse response,
+		@NonNull final FilterChain filterChain
 	) throws ServletException, IOException {
 		final String authHeader = request.getHeader("Authorization");
 		final String jwt;

--- a/src/main/java/com/programmers/bucketback/global/config/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/programmers/bucketback/global/config/security/jwt/JwtAuthenticationFilter.java
@@ -32,7 +32,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	) throws ServletException, IOException {
 		final String authHeader = request.getHeader("Authorization");
 		final String jwt;
-		final String userEmail;
+		final String memberId;
 
 		if (authHeader == null || !authHeader.startsWith("Bearer ")) {
 			filterChain.doFilter(request, response);
@@ -40,11 +40,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		}
 
 		jwt = authHeader.substring(7);
-		userEmail = jwtService.extractUsername(jwt);
+		memberId = jwtService.extractUsername(jwt);
 
-		if (userEmail != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+		if (memberId != null && SecurityContextHolder.getContext().getAuthentication() == null) {
 
-			UserDetails userDetails = this.userDetailsService.loadUserByUsername(userEmail);
+			UserDetails userDetails = this.userDetailsService.loadUserByUsername(memberId);
 
 			if (jwtService.isTokenValid(jwt, userDetails)) {
 				UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(

--- a/src/main/java/com/programmers/bucketback/global/config/security/jwt/JwtService.java
+++ b/src/main/java/com/programmers/bucketback/global/config/security/jwt/JwtService.java
@@ -22,20 +22,26 @@ public class JwtService {
 
 	private final JwtConfig jwtConfig;
 
-	public String extractUsername(String token) {
+	public String extractUsername(final String token) {
 		return extractClaim(token, Claims::getSubject);
 	}
 
-	public <T> T extractClaim(String token, Function<Claims, T> claimsTResolver) {
+	public <T> T extractClaim(
+		final String token,
+		final Function<Claims, T> claimsTResolver
+	) {
 		final Claims claims = extractAllClaims(token);
 		return claimsTResolver.apply(claims);
 	}
 
-	public String generateToken(UserDetails userDetails) {
+	public String generateToken(final UserDetails userDetails) {
 		return generateToken(new HashMap<>(), userDetails);
 	}
 
-	public String generateToken(Map<String, Object> extraClaims, UserDetails userDetails) {
+	public String generateToken(
+		final Map<String, Object> extraClaims,
+		final UserDetails userDetails
+	) {
 		return Jwts.builder()
 			.setClaims(extraClaims)
 			.setSubject(userDetails.getUsername())
@@ -45,20 +51,23 @@ public class JwtService {
 			.compact();
 	}
 
-	public boolean isTokenValid(String token, UserDetails userDetails) {
+	public boolean isTokenValid(
+		final String token,
+		final UserDetails userDetails
+	) {
 		final String username = extractUsername(token);
 		return (username.equals(userDetails.getUsername())) && !isTokenExpired(token);
 	}
 
-	private boolean isTokenExpired(String token) {
+	private boolean isTokenExpired(final String token) {
 		return extractExpiratiob(token).before(new Date());
 	}
 
-	private Date extractExpiratiob(String token) {
+	private Date extractExpiratiob(final String token) {
 		return extractClaim(token, Claims::getExpiration);
 	}
 
-	private Claims extractAllClaims(String token) {
+	private Claims extractAllClaims(final String token) {
 		return Jwts
 			.parserBuilder()
 			.setSigningKey(getSignInKey())

--- a/src/main/java/com/programmers/bucketback/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/programmers/bucketback/global/error/exception/ErrorCode.java
@@ -10,6 +10,7 @@ public enum ErrorCode {
 	// Common
 	INTERNAL_SERVER_ERROR("COMMON_001", "Internal Server Error"),
 	INVALID_REQUEST("COMMON_002", "유효하지 않은 요청입니다."),
+	SECURITY_CONTEXT_NOT_FOUND("COMMON_003", "Security context를 찾을 수 없습니다."),
 
 	// Member
 	MEMBER_LOGIN_FAIL("MEMBER_001", "로그인 정보가 잘못 되었습니다."),

--- a/src/main/java/com/programmers/bucketback/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/programmers/bucketback/global/error/exception/ErrorCode.java
@@ -15,7 +15,8 @@ public enum ErrorCode {
 	// Member
 	MEMBER_LOGIN_FAIL("MEMBER_001", "로그인 정보가 잘못 되었습니다."),
 	MEMBER_NOT_FOUND("MEMBER_002", "회원을 찾을 수 없습니다."),
-	MEMBER_ANONYMOUS("MEMBER_003", "익명의 사용자 입니다.")
+	MEMBER_ANONYMOUS("MEMBER_003", "익명의 사용자 입니다."),
+	MEMBER_DELETED("MEMBER_003", "탈퇴한 회원 입니다."),
 	;
 
 	private final String code;

--- a/src/main/java/com/programmers/bucketback/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/programmers/bucketback/global/error/exception/ErrorCode.java
@@ -10,10 +10,12 @@ public enum ErrorCode {
 	// Common
 	INTERNAL_SERVER_ERROR("COMMON_001", "Internal Server Error"),
 	INVALID_REQUEST("COMMON_002", "유효하지 않은 요청입니다."),
+	SECURITY_CONTEXT_NOT_FOUND("COMMON_003", "Security context를 찾을 수 없습니다."),
 
 	// Member
 	MEMBER_LOGIN_FAIL("MEMBER_001", "로그인 정보가 잘못 되었습니다."),
 	MEMBER_NOT_FOUND("MEMBER_002", "회원을 찾을 수 없습니다."),
+	MEMBER_ANONYMOUS("MEMBER_003", "익명의 사용자 입니다.")
 	;
 
 	private final String code;


### PR DESCRIPTION
## 📌 PR 종류

어떤 종류의 PR인지 아래 항목 중에 체크 해주세요.
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [ ]  🐛 버그 수정
- [x]  ✨ 기능 추가
- [ ]  **✅** 테스트 추가
- [ ]  🎨 코드 스타일 변경 (formatting, local variables)
- [ ]  🔨 리팩토링 (기능 변경 X)
- [ ]  **💚** 빌드 관련 수정
- [ ]  **📝** 문서 내용 수정
- [ ]  그 외, 어떤 종류인지 기입 바람:
<br>

## 📌 어떤 기능이 추가 되었나요?

<!--어떤 기능이 추가 되었는지 설명해주시고 관련된 지라 이슈 넘버를 추가 해주세요 -->

### Issue Number

OMCT-51

### 기능 설명
- JWT 토큰에 email 대신 memberId를 저장하도록 변경하였습니다.
- 회원 삭제 시 SecurityContext에서 memberId를 가져와서 회원을 조회합니다. 조회한 회원의 상태값을 DELTED로 변경합니다.
- BaseEntity의 createAt은 변경되지 않도록 @Column애 명시해주었습니다.  

<br>

## 📌 기존에 있던 기능에 영향을 주나요?

- [x]  네
- [ ]  아니요

<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->

탈퇴한 회원을 로그인을 할 수 없도록 로그인 실패 로직을 추가하였습니다.
