### PR TITLE
[OMCT-37] 멤버 아이템 삭제 기능 추가

### DIFF
--- a/src/main/java/com/programmers/bucketback/domains/item/api/ItemController.java
+++ b/src/main/java/com/programmers/bucketback/domains/item/api/ItemController.java
@@ -1,6 +1,7 @@
 package com.programmers.bucketback.domains.item.api;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -46,5 +47,12 @@ public class ItemController {
 		GetItemServiceResponse response = itemService.getItemDetails(itemId);
 
 		return ResponseEntity.ok(response.toItemGetResponse());
+	}
+
+	@DeleteMapping("/myItems/{itemId}")
+	public ResponseEntity<Void> deleteMyItem(@PathVariable final Long itemId) {
+		itemService.removeMemberItem(itemId);
+
+		return ResponseEntity.ok().build();
 	}
 }

--- a/src/main/java/com/programmers/bucketback/domains/item/application/ItemService.java
+++ b/src/main/java/com/programmers/bucketback/domains/item/application/ItemService.java
@@ -6,6 +6,7 @@ import com.programmers.bucketback.domains.common.MemberUtils;
 import com.programmers.bucketback.domains.item.application.dto.AddMemberItemServiceRequest;
 import com.programmers.bucketback.domains.item.application.dto.GetItemServiceResponse;
 import com.programmers.bucketback.domains.item.domain.Item;
+import com.programmers.bucketback.domains.item.domain.MemberItem;
 import com.programmers.bucketback.domains.review.application.ReviewStatistics;
 
 import lombok.RequiredArgsConstructor;
@@ -18,6 +19,8 @@ public class ItemService {
 	private final MemberItemChecker memberItemChecker;
 	private final ItemReader itemReader;
 	private final ReviewStatistics reviewStatistics;
+	private final MemberItemReader memberItemReader;
+	private final MemberItemRemover memberItemRemover;
 
 	public void addItem(final AddMemberItemServiceRequest request) {
 		Long memberId = MemberUtils.getCurrentMemberId();
@@ -44,5 +47,11 @@ public class ItemService {
 			.itemName(item.getName())
 			.itemImage(item.getImage())
 			.build();
+	}
+
+	public void removeMemberItem(final Long itemId) {
+		Long memberId = MemberUtils.getCurrentMemberId();
+		MemberItem memberItem = memberItemReader.read(itemId, memberId);
+		memberItemRemover.remove(memberItem.getId());
 	}
 }

--- a/src/main/java/com/programmers/bucketback/domains/item/application/MemberItemReader.java
+++ b/src/main/java/com/programmers/bucketback/domains/item/application/MemberItemReader.java
@@ -1,0 +1,33 @@
+package com.programmers.bucketback.domains.item.application;
+
+import org.springframework.stereotype.Component;
+
+import com.programmers.bucketback.domains.item.domain.Item;
+import com.programmers.bucketback.domains.item.domain.MemberItem;
+import com.programmers.bucketback.domains.item.repository.MemberItemRepository;
+import com.programmers.bucketback.global.error.exception.EntityNotFoundException;
+import com.programmers.bucketback.global.error.exception.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class MemberItemReader {
+
+	private final MemberItemRepository memberItemRepository;
+	private final ItemReader itemReader;
+
+	public MemberItem read(final Long memberItemId) {
+		return memberItemRepository.findById(memberItemId)
+			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.MEMBER_ITEM_NOT_FOUND));
+	}
+
+	public MemberItem read(
+		final Long itemId,
+		final Long memberIteId
+	) {
+		Item item = itemReader.read(itemId);
+		return memberItemRepository.findMemberItemByMembersIdAndItem(memberIteId, item)
+			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.MEMBER_ITEM_NOT_FOUND));
+	}
+}

--- a/src/main/java/com/programmers/bucketback/domains/item/application/MemberItemRemover.java
+++ b/src/main/java/com/programmers/bucketback/domains/item/application/MemberItemRemover.java
@@ -1,0 +1,21 @@
+package com.programmers.bucketback.domains.item.application;
+
+import org.springframework.stereotype.Component;
+
+import com.programmers.bucketback.domains.item.domain.MemberItem;
+import com.programmers.bucketback.domains.item.repository.MemberItemRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class MemberItemRemover {
+
+	private final MemberItemReader memberItemReader;
+	private final MemberItemRepository memberItemRepository;
+
+	public void remove(final Long memberItemId) {
+		MemberItem memberItem = memberItemReader.read(memberItemId);
+		memberItemRepository.delete(memberItem);
+	}
+}

--- a/src/main/java/com/programmers/bucketback/domains/item/repository/MemberItemRepository.java
+++ b/src/main/java/com/programmers/bucketback/domains/item/repository/MemberItemRepository.java
@@ -1,5 +1,7 @@
 package com.programmers.bucketback.domains.item.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.programmers.bucketback.domains.item.domain.Item;
@@ -8,4 +10,6 @@ import com.programmers.bucketback.domains.item.domain.MemberItem;
 public interface MemberItemRepository extends JpaRepository<MemberItem, Long> {
 
 	boolean existsMemberItemByMembersIdAndItem(Long memberId, Item item);
+
+	Optional<MemberItem> findMemberItemByMembersIdAndItem(Long memberId, Item item);
 }


### PR DESCRIPTION
## 📌 PR 종류

어떤 종류의 PR인지 아래 항목 중에 체크 해주세요.
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [ ]  🐛 버그 수정
- [x]  ✨ 기능 추가
- [ ]  **✅** 테스트 추가
- [ ]  🎨 코드 스타일 변경 (formatting, local variables)
- [ ]  🔨 리팩토링 (기능 변경 X)
- [ ]  **💚** 빌드 관련 수정
- [ ]  **📝** 문서 내용 수정
- [ ]  그 외, 어떤 종류인지 기입 바람:
<br>

## 📌 어떤 기능이 추가 되었나요?

<!--어떤 기능이 추가 되었는지 설명해주시고 관련된 지라 이슈 넘버를 추가 해주세요 -->

### Issue Number

OMCT-37

### 기능 설명

사용자가 담은 아이템 삭제 하는 기능 추가 하였습니다.
- 아이템 아이디와 일치하는 아이템을 사용자가 가지고 있다면 MEMBERS_ITEMS 테이블에서 삭제 합니다. 

## 📌 기존에 있던 기능에 영향을 주나요?

- [ ]  네
- [x]  아니요

<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->
