### PR TITLE
[OMCT-95] Vote 조건 검색 + 커서 페이지네이션 구현

### DIFF
--- a/src/main/java/com/programmers/bucketback/domains/common/vo/CursorPageParameters.java
+++ b/src/main/java/com/programmers/bucketback/domains/common/vo/CursorPageParameters.java
@@ -2,6 +2,6 @@ package com.programmers.bucketback.domains.common.vo;
 
 public record CursorPageParameters(
 	String cursorId,
-	int size
+	Integer size
 ) {
 }

--- a/src/main/java/com/programmers/bucketback/domains/common/vo/CursorRequest.java
+++ b/src/main/java/com/programmers/bucketback/domains/common/vo/CursorRequest.java
@@ -8,10 +8,10 @@ public record CursorRequest(
 	String cursorId,
 
 	@Schema(description = "페이징 사이즈입니다", example = "10")
-	int size
+	Integer size
 
 ) {
-	public CursorPageParameters toParameters(){
+	public CursorPageParameters toParameters() {
 		return new CursorPageParameters(cursorId, size);
 	}
 }

--- a/src/main/java/com/programmers/bucketback/domains/vote/api/VoteController.java
+++ b/src/main/java/com/programmers/bucketback/domains/vote/api/VoteController.java
@@ -3,18 +3,26 @@ package com.programmers.bucketback.domains.vote.api;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.programmers.bucketback.domains.common.Hobby;
+import com.programmers.bucketback.domains.common.vo.CursorRequest;
 import com.programmers.bucketback.domains.vote.api.dto.request.VoteCreateRequest;
 import com.programmers.bucketback.domains.vote.api.dto.request.VoteParticipateRequest;
 import com.programmers.bucketback.domains.vote.api.dto.response.VoteCreateResponse;
+import com.programmers.bucketback.domains.vote.api.dto.response.VoteGetByCursorResponse;
 import com.programmers.bucketback.domains.vote.api.dto.response.VoteGetResponse;
 import com.programmers.bucketback.domains.vote.application.VoteService;
+import com.programmers.bucketback.domains.vote.application.VoteSortCondition;
+import com.programmers.bucketback.domains.vote.application.VoteStatusCondition;
 import com.programmers.bucketback.domains.vote.application.dto.response.GetVoteServiceResponse;
+import com.programmers.bucketback.domains.vote.application.dto.response.GetVotesServiceResponse;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -29,7 +37,7 @@ public class VoteController {
 	@PostMapping
 	public ResponseEntity<VoteCreateResponse> createVote(@Valid @RequestBody final VoteCreateRequest request) {
 		final Long voteId = voteService.createVote(request.toCreateVoteServiceRequest());
-		VoteCreateResponse response = new VoteCreateResponse(voteId);
+		final VoteCreateResponse response = new VoteCreateResponse(voteId);
 
 		return ResponseEntity.ok(response);
 	}
@@ -53,9 +61,28 @@ public class VoteController {
 
 	@GetMapping("{voteId}")
 	public ResponseEntity<VoteGetResponse> getVote(@PathVariable final Long voteId) {
-		GetVoteServiceResponse voteServiceResponse = voteService.getVote(voteId);
-		VoteGetResponse response = VoteGetResponse.from(voteServiceResponse);
+		final GetVoteServiceResponse voteServiceResponse = voteService.getVote(voteId);
+		final VoteGetResponse response = VoteGetResponse.from(voteServiceResponse);
 
 		return ResponseEntity.ok(response);
 	}
+
+	@GetMapping
+	public ResponseEntity<VoteGetByCursorResponse> getVotesByCursor(
+		@RequestParam final String hobby,
+		@RequestParam(name = "status") final String statusCondition,
+		@RequestParam(required = false, name = "sort") final String sortCondition,
+		@ModelAttribute @Valid final CursorRequest request
+	) {
+		final GetVotesServiceResponse serviceResponse = voteService.getVotesByCursor(
+			Hobby.valueOf(hobby.toUpperCase()),
+			VoteStatusCondition.valueOf(statusCondition.toUpperCase()),
+			sortCondition == null ? VoteSortCondition.RECENT : VoteSortCondition.valueOf(sortCondition.toUpperCase()),
+			request.toParameters()
+		);
+		final VoteGetByCursorResponse response = VoteGetByCursorResponse.from(serviceResponse);
+
+		return ResponseEntity.ok(response);
+	}
+
 }

--- a/src/main/java/com/programmers/bucketback/domains/vote/api/VoteController.java
+++ b/src/main/java/com/programmers/bucketback/domains/vote/api/VoteController.java
@@ -19,7 +19,6 @@ import com.programmers.bucketback.domains.vote.api.dto.response.VoteCreateRespon
 import com.programmers.bucketback.domains.vote.api.dto.response.VoteGetByCursorResponse;
 import com.programmers.bucketback.domains.vote.api.dto.response.VoteGetResponse;
 import com.programmers.bucketback.domains.vote.application.VoteService;
-import com.programmers.bucketback.domains.vote.application.VoteSortCondition;
 import com.programmers.bucketback.domains.vote.application.VoteStatusCondition;
 import com.programmers.bucketback.domains.vote.application.dto.response.GetVoteServiceResponse;
 import com.programmers.bucketback.domains.vote.application.dto.response.GetVotesServiceResponse;
@@ -77,7 +76,7 @@ public class VoteController {
 		final GetVotesServiceResponse serviceResponse = voteService.getVotesByCursor(
 			Hobby.valueOf(hobby.toUpperCase()),
 			VoteStatusCondition.valueOf(statusCondition.toUpperCase()),
-			sortCondition == null ? VoteSortCondition.RECENT : VoteSortCondition.valueOf(sortCondition.toUpperCase()),
+			sortCondition,
 			request.toParameters()
 		);
 		final VoteGetByCursorResponse response = VoteGetByCursorResponse.from(serviceResponse);

--- a/src/main/java/com/programmers/bucketback/domains/vote/api/dto/response/VoteGetByCursorResponse.java
+++ b/src/main/java/com/programmers/bucketback/domains/vote/api/dto/response/VoteGetByCursorResponse.java
@@ -1,0 +1,15 @@
+package com.programmers.bucketback.domains.vote.api.dto.response;
+
+import java.util.List;
+
+import com.programmers.bucketback.domains.vote.application.VoteCursorSummary;
+import com.programmers.bucketback.domains.vote.application.dto.response.GetVotesServiceResponse;
+
+public record VoteGetByCursorResponse(
+	String nextCursorId,
+	List<VoteCursorSummary> voteCursorSummaries
+) {
+	public static VoteGetByCursorResponse from(final GetVotesServiceResponse serviceResponse) {
+		return new VoteGetByCursorResponse(serviceResponse.nextCursorId(), serviceResponse.voteCursorSummaries());
+	}
+}

--- a/src/main/java/com/programmers/bucketback/domains/vote/application/VoteAppender.java
+++ b/src/main/java/com/programmers/bucketback/domains/vote/application/VoteAppender.java
@@ -5,7 +5,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.programmers.bucketback.domains.vote.application.dto.request.CreateVoteServiceRequest;
 import com.programmers.bucketback.domains.vote.domain.Vote;
-import com.programmers.bucketback.domains.vote.repository.VoteReposiory;
+import com.programmers.bucketback.domains.vote.repository.VoteRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -13,7 +13,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class VoteAppender {
 
-	private final VoteReposiory voteReposiory;
+	private final VoteRepository voteRepository;
 
 	@Transactional
 	public Vote append(
@@ -28,6 +28,6 @@ public class VoteAppender {
 			.content(request.content())
 			.build();
 
-		return voteReposiory.save(vote);
+		return voteRepository.save(vote);
 	}
 }

--- a/src/main/java/com/programmers/bucketback/domains/vote/application/VoteCursorSummary.java
+++ b/src/main/java/com/programmers/bucketback/domains/vote/application/VoteCursorSummary.java
@@ -1,0 +1,12 @@
+package com.programmers.bucketback.domains.vote.application;
+
+import lombok.Builder;
+
+@Builder
+public record VoteCursorSummary(
+	VoteInfo voteInfo,
+	OptionItem option1Item,
+	OptionItem option2Item,
+	String cursorId
+) {
+}

--- a/src/main/java/com/programmers/bucketback/domains/vote/application/VoteCursorSummary.java
+++ b/src/main/java/com/programmers/bucketback/domains/vote/application/VoteCursorSummary.java
@@ -1,5 +1,7 @@
 package com.programmers.bucketback.domains.vote.application;
 
+import com.programmers.bucketback.domains.item.domain.Item;
+
 import lombok.Builder;
 
 @Builder
@@ -9,4 +11,16 @@ public record VoteCursorSummary(
 	OptionItem option2Item,
 	String cursorId
 ) {
+	public static VoteCursorSummary of(
+		final VoteSummary voteSummary,
+		final Item item1,
+		final Item item2
+	) {
+		return VoteCursorSummary.builder()
+			.voteInfo(voteSummary.voteInfo())
+			.option1Item(OptionItem.from(item1))
+			.option2Item(OptionItem.from(item2))
+			.cursorId(voteSummary.cursorId())
+			.build();
+	}
 }

--- a/src/main/java/com/programmers/bucketback/domains/vote/application/VoteInfo.java
+++ b/src/main/java/com/programmers/bucketback/domains/vote/application/VoteInfo.java
@@ -21,14 +21,14 @@ public record VoteInfo(
 	@JsonInclude(JsonInclude.Include.NON_NULL)
 	Integer option2Votes
 ) {
-	public static VoteInfo from(final Vote vote) {
-		return VoteInfo.builder()
-			.id(vote.getId())
-			.content(vote.getContent())
-			.startTime(vote.getStartTime())
-			.isVoting(isVoting(vote.getEndTime()))
-			.participants(vote.getVoters().size())
-			.build();
+	public VoteInfo(
+		final Long id,
+		final String content,
+		final LocalDateTime startTime,
+		final LocalDateTime endTime,
+		final int participants
+	) {
+		this(id, content, startTime, isVoting(endTime), participants, null, null);
 	}
 
 	public static VoteInfo of(

--- a/src/main/java/com/programmers/bucketback/domains/vote/application/VoteInfo.java
+++ b/src/main/java/com/programmers/bucketback/domains/vote/application/VoteInfo.java
@@ -21,6 +21,16 @@ public record VoteInfo(
 	@JsonInclude(JsonInclude.Include.NON_NULL)
 	Integer option2Votes
 ) {
+	public static VoteInfo from(final Vote vote) {
+		return VoteInfo.builder()
+			.id(vote.getId())
+			.content(vote.getContent())
+			.createAt(vote.getCreatedAt())
+			.isVoting(isVoting(vote.getEndTime()))
+			.participants(vote.getVoters().size())
+			.build();
+	}
+
 	public static VoteInfo of(
 		final Vote vote,
 		final int option1Votes,

--- a/src/main/java/com/programmers/bucketback/domains/vote/application/VoteInfo.java
+++ b/src/main/java/com/programmers/bucketback/domains/vote/application/VoteInfo.java
@@ -11,7 +11,7 @@ import lombok.Builder;
 public record VoteInfo(
 	Long id,
 	String content,
-	LocalDateTime createAt,
+	LocalDateTime startTime,
 	boolean isVoting,
 	int participants,
 
@@ -25,7 +25,7 @@ public record VoteInfo(
 		return VoteInfo.builder()
 			.id(vote.getId())
 			.content(vote.getContent())
-			.createAt(vote.getCreatedAt())
+			.startTime(vote.getStartTime())
 			.isVoting(isVoting(vote.getEndTime()))
 			.participants(vote.getVoters().size())
 			.build();
@@ -39,7 +39,7 @@ public record VoteInfo(
 		return VoteInfo.builder()
 			.id(vote.getId())
 			.content(vote.getContent())
-			.createAt(vote.getCreatedAt())
+			.startTime(vote.getStartTime())
 			.isVoting(isVoting(vote.getEndTime()))
 			.participants(option1Votes + option2Votes)
 			.option1Votes(option1Votes)

--- a/src/main/java/com/programmers/bucketback/domains/vote/application/VoteReader.java
+++ b/src/main/java/com/programmers/bucketback/domains/vote/application/VoteReader.java
@@ -35,13 +35,15 @@ public class VoteReader {
 	public GetVotesServiceResponse readByCursor(
 		final Hobby hobby,
 		final VoteStatusCondition statusCondition,
-		VoteSortCondition sortCondition,
+		final String sortCondition,
 		final CursorPageParameters parameters
 	) {
 		final int pageSize = parameters.size() == null ? 20 : parameters.size();
 
-		if (statusCondition != VoteStatusCondition.COMPLETED || sortCondition != VoteSortCondition.POPULARITY) {
-			sortCondition = VoteSortCondition.RECENT;
+		VoteSortCondition voteSortCondition = VoteSortCondition.RECENT;
+		if (statusCondition == VoteStatusCondition.COMPLETED
+			&& sortCondition != null && sortCondition.equals("popularity")) {
+			voteSortCondition = VoteSortCondition.POPULARITY;
 		}
 
 		Long memberId = null;
@@ -52,7 +54,7 @@ public class VoteReader {
 		final List<VoteSummary> voteSummaries = voteRepository.findAllByCursor(
 			hobby,
 			statusCondition,
-			sortCondition,
+			voteSortCondition,
 			memberId,
 			parameters.cursorId(),
 			pageSize

--- a/src/main/java/com/programmers/bucketback/domains/vote/application/VoteReader.java
+++ b/src/main/java/com/programmers/bucketback/domains/vote/application/VoteReader.java
@@ -87,14 +87,14 @@ public class VoteReader {
 	private List<VoteCursorSummary> getVoteCursorSummaries(final List<VoteSummary> voteSummaries) {
 		final List<VoteCursorSummary> voteCursorSummaries = new ArrayList<>();
 		for (final VoteSummary voteSummary : voteSummaries) {
-			final Long option1ItemId = voteSummary.vote().getOption1ItemId();
+			final Long option1ItemId = voteSummary.option1ItemId();
 			final Item item1 = itemReader.read(option1ItemId);
-			final Long option2ItemId = voteSummary.vote().getOption2ItemId();
+			final Long option2ItemId = voteSummary.option2ItemId();
 			final Item item2 = itemReader.read(option2ItemId);
 
 			voteCursorSummaries.add(
 				VoteCursorSummary.builder()
-					.voteInfo(VoteInfo.from(voteSummary.vote()))
+					.voteInfo(voteSummary.voteInfo())
 					.option1Item(OptionItem.from(item1))
 					.option2Item(OptionItem.from(item2))
 					.cursorId(voteSummary.cursorId())

--- a/src/main/java/com/programmers/bucketback/domains/vote/application/VoteReader.java
+++ b/src/main/java/com/programmers/bucketback/domains/vote/application/VoteReader.java
@@ -92,14 +92,7 @@ public class VoteReader {
 			final Long option2ItemId = voteSummary.option2ItemId();
 			final Item item2 = itemReader.read(option2ItemId);
 
-			voteCursorSummaries.add(
-				VoteCursorSummary.builder()
-					.voteInfo(voteSummary.voteInfo())
-					.option1Item(OptionItem.from(item1))
-					.option2Item(OptionItem.from(item2))
-					.cursorId(voteSummary.cursorId())
-					.build()
-			);
+			voteCursorSummaries.add(VoteCursorSummary.of(voteSummary, item1, item2));
 		}
 
 		return voteCursorSummaries;

--- a/src/main/java/com/programmers/bucketback/domains/vote/application/VoteReader.java
+++ b/src/main/java/com/programmers/bucketback/domains/vote/application/VoteReader.java
@@ -1,6 +1,7 @@
 package com.programmers.bucketback.domains.vote.application;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.springframework.stereotype.Component;
@@ -49,6 +50,10 @@ public class VoteReader {
 		Long memberId = null;
 		if (MemberUtils.isLoggedIn()) {
 			memberId = MemberUtils.getCurrentMemberId();
+		}
+
+		if (memberId == null && statusCondition.isRequiredLogin()) {
+			return new GetVotesServiceResponse(null, Collections.emptyList());
 		}
 
 		final List<VoteSummary> voteSummaries = voteRepository.findAllByCursor(

--- a/src/main/java/com/programmers/bucketback/domains/vote/application/VoteReader.java
+++ b/src/main/java/com/programmers/bucketback/domains/vote/application/VoteReader.java
@@ -4,7 +4,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.programmers.bucketback.domains.vote.domain.Vote;
-import com.programmers.bucketback.domains.vote.repository.VoteReposiory;
+import com.programmers.bucketback.domains.vote.repository.VoteRepository;
 import com.programmers.bucketback.global.error.exception.EntityNotFoundException;
 import com.programmers.bucketback.global.error.exception.ErrorCode;
 
@@ -14,11 +14,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class VoteReader {
 
-	private final VoteReposiory voteReposiory;
+	private final VoteRepository voteRepository;
 
 	@Transactional(readOnly = true)
 	public Vote read(final Long voteId) {
-		return voteReposiory.findById(voteId)
+		return voteRepository.findById(voteId)
 			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.VOTE_NOT_FOUND));
 	}
 }

--- a/src/main/java/com/programmers/bucketback/domains/vote/application/VoteReader.java
+++ b/src/main/java/com/programmers/bucketback/domains/vote/application/VoteReader.java
@@ -1,8 +1,17 @@
 package com.programmers.bucketback.domains.vote.application;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.programmers.bucketback.domains.common.Hobby;
+import com.programmers.bucketback.domains.common.MemberUtils;
+import com.programmers.bucketback.domains.common.vo.CursorPageParameters;
+import com.programmers.bucketback.domains.item.application.ItemReader;
+import com.programmers.bucketback.domains.item.domain.Item;
+import com.programmers.bucketback.domains.vote.application.dto.response.GetVotesServiceResponse;
 import com.programmers.bucketback.domains.vote.domain.Vote;
 import com.programmers.bucketback.domains.vote.repository.VoteRepository;
 import com.programmers.bucketback.global.error.exception.EntityNotFoundException;
@@ -15,10 +24,69 @@ import lombok.RequiredArgsConstructor;
 public class VoteReader {
 
 	private final VoteRepository voteRepository;
+	private final ItemReader itemReader;
 
 	@Transactional(readOnly = true)
 	public Vote read(final Long voteId) {
 		return voteRepository.findById(voteId)
 			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.VOTE_NOT_FOUND));
+	}
+
+	public GetVotesServiceResponse readByCursor(
+		final Hobby hobby,
+		final VoteStatusCondition statusCondition,
+		VoteSortCondition sortCondition,
+		final CursorPageParameters parameters
+	) {
+		final int pageSize = parameters.size() == null ? 20 : parameters.size();
+
+		if (statusCondition != VoteStatusCondition.COMPLETED || sortCondition != VoteSortCondition.POPULARITY) {
+			sortCondition = VoteSortCondition.RECENT;
+		}
+
+		Long memberId = null;
+		if (MemberUtils.isLoggedIn()) {
+			memberId = MemberUtils.getCurrentMemberId();
+		}
+
+		final List<VoteSummary> voteSummaries = voteRepository.findAllByCursor(
+			hobby,
+			statusCondition,
+			sortCondition,
+			memberId,
+			parameters.cursorId(),
+			pageSize
+		);
+
+		final List<VoteCursorSummary> voteCursorSummaries = getVoteCursorSummaries(voteSummaries);
+		final String nextCursorId = getNextCursorId(voteSummaries);
+
+		return new GetVotesServiceResponse(nextCursorId, voteCursorSummaries);
+	}
+
+	private List<VoteCursorSummary> getVoteCursorSummaries(final List<VoteSummary> voteSummaries) {
+		final List<VoteCursorSummary> voteCursorSummaries = new ArrayList<>();
+		for (final VoteSummary voteSummary : voteSummaries) {
+			final Long option1ItemId = voteSummary.vote().getOption1ItemId();
+			final Item item1 = itemReader.read(option1ItemId);
+			final Long option2ItemId = voteSummary.vote().getOption2ItemId();
+			final Item item2 = itemReader.read(option2ItemId);
+
+			voteCursorSummaries.add(
+				VoteCursorSummary.builder()
+					.voteInfo(VoteInfo.from(voteSummary.vote()))
+					.option1Item(OptionItem.from(item1))
+					.option2Item(OptionItem.from(item2))
+					.cursorId(voteSummary.cursorId())
+					.build()
+			);
+		}
+
+		return voteCursorSummaries;
+	}
+
+	private String getNextCursorId(final List<VoteSummary> voteSummaries) {
+		final int votesSize = voteSummaries.size();
+		return votesSize == 0 ? null : voteSummaries.get(votesSize - 1).cursorId();
 	}
 }

--- a/src/main/java/com/programmers/bucketback/domains/vote/application/VoteRemover.java
+++ b/src/main/java/com/programmers/bucketback/domains/vote/application/VoteRemover.java
@@ -4,7 +4,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.programmers.bucketback.domains.vote.domain.Vote;
-import com.programmers.bucketback.domains.vote.repository.VoteReposiory;
+import com.programmers.bucketback.domains.vote.repository.VoteRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -12,10 +12,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class VoteRemover {
 
-	private final VoteReposiory voteReposiory;
+	private final VoteRepository voteRepository;
 
 	@Transactional
 	public void remove(final Vote vote) {
-		voteReposiory.delete(vote);
+		voteRepository.delete(vote);
 	}
 }

--- a/src/main/java/com/programmers/bucketback/domains/vote/application/VoteService.java
+++ b/src/main/java/com/programmers/bucketback/domains/vote/application/VoteService.java
@@ -4,11 +4,14 @@ import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 
+import com.programmers.bucketback.domains.common.Hobby;
 import com.programmers.bucketback.domains.common.MemberUtils;
+import com.programmers.bucketback.domains.common.vo.CursorPageParameters;
 import com.programmers.bucketback.domains.item.application.ItemReader;
 import com.programmers.bucketback.domains.item.domain.Item;
 import com.programmers.bucketback.domains.vote.application.dto.request.CreateVoteServiceRequest;
 import com.programmers.bucketback.domains.vote.application.dto.response.GetVoteServiceResponse;
+import com.programmers.bucketback.domains.vote.application.dto.response.GetVotesServiceResponse;
 import com.programmers.bucketback.domains.vote.domain.Vote;
 import com.programmers.bucketback.domains.vote.domain.Voter;
 import com.programmers.bucketback.global.error.exception.BusinessException;
@@ -87,6 +90,15 @@ public class VoteService {
 			.isOwner(isOwner)
 			.selectedItemId(selectedItemId)
 			.build();
+	}
+
+	public GetVotesServiceResponse getVotesByCursor(
+		final Hobby hobby,
+		final VoteStatusCondition statusCondition,
+		final VoteSortCondition sortCondition,
+		final CursorPageParameters parameters
+	) {
+		return voteReader.readByCursor(hobby, statusCondition, sortCondition, parameters);
 	}
 
 	private boolean isOwner(

--- a/src/main/java/com/programmers/bucketback/domains/vote/application/VoteService.java
+++ b/src/main/java/com/programmers/bucketback/domains/vote/application/VoteService.java
@@ -95,7 +95,7 @@ public class VoteService {
 	public GetVotesServiceResponse getVotesByCursor(
 		final Hobby hobby,
 		final VoteStatusCondition statusCondition,
-		final VoteSortCondition sortCondition,
+		final String sortCondition,
 		final CursorPageParameters parameters
 	) {
 		return voteReader.readByCursor(hobby, statusCondition, sortCondition, parameters);

--- a/src/main/java/com/programmers/bucketback/domains/vote/application/VoteSortCondition.java
+++ b/src/main/java/com/programmers/bucketback/domains/vote/application/VoteSortCondition.java
@@ -1,0 +1,6 @@
+package com.programmers.bucketback.domains.vote.application;
+
+public enum VoteSortCondition {
+	POPULARITY,
+	RECENT
+}

--- a/src/main/java/com/programmers/bucketback/domains/vote/application/VoteStatusCondition.java
+++ b/src/main/java/com/programmers/bucketback/domains/vote/application/VoteStatusCondition.java
@@ -4,5 +4,9 @@ public enum VoteStatusCondition {
 	INPROGRESS,
 	COMPLETED,
 	POSTED,
-	PARTICIPATED
+	PARTICIPATED;
+
+	public boolean isRequiredLogin() {
+		return this == POSTED || this == PARTICIPATED;
+	}
 }

--- a/src/main/java/com/programmers/bucketback/domains/vote/application/VoteStatusCondition.java
+++ b/src/main/java/com/programmers/bucketback/domains/vote/application/VoteStatusCondition.java
@@ -1,0 +1,8 @@
+package com.programmers.bucketback.domains.vote.application;
+
+public enum VoteStatusCondition {
+	INPROGRESS,
+	COMPLETED,
+	POSTED,
+	PARTICIPATED
+}

--- a/src/main/java/com/programmers/bucketback/domains/vote/application/VoteSummary.java
+++ b/src/main/java/com/programmers/bucketback/domains/vote/application/VoteSummary.java
@@ -1,9 +1,9 @@
 package com.programmers.bucketback.domains.vote.application;
 
-import com.programmers.bucketback.domains.vote.domain.Vote;
-
 public record VoteSummary(
-	Vote vote,
+	VoteInfo voteInfo,
+	Long option1ItemId,
+	Long option2ItemId,
 	String cursorId
 ) {
 }

--- a/src/main/java/com/programmers/bucketback/domains/vote/application/VoteSummary.java
+++ b/src/main/java/com/programmers/bucketback/domains/vote/application/VoteSummary.java
@@ -1,0 +1,9 @@
+package com.programmers.bucketback.domains.vote.application;
+
+import com.programmers.bucketback.domains.vote.domain.Vote;
+
+public record VoteSummary(
+	Vote vote,
+	String cursorId
+) {
+}

--- a/src/main/java/com/programmers/bucketback/domains/vote/application/dto/response/GetVotesServiceResponse.java
+++ b/src/main/java/com/programmers/bucketback/domains/vote/application/dto/response/GetVotesServiceResponse.java
@@ -1,0 +1,11 @@
+package com.programmers.bucketback.domains.vote.application.dto.response;
+
+import java.util.List;
+
+import com.programmers.bucketback.domains.vote.application.VoteCursorSummary;
+
+public record GetVotesServiceResponse(
+	String nextCursorId,
+	List<VoteCursorSummary> voteCursorSummaries
+) {
+}

--- a/src/main/java/com/programmers/bucketback/domains/vote/repository/VoteRepository.java
+++ b/src/main/java/com/programmers/bucketback/domains/vote/repository/VoteRepository.java
@@ -4,5 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.programmers.bucketback.domains.vote.domain.Vote;
 
-public interface VoteRepository extends JpaRepository<Vote, Long> {
+public interface VoteRepository extends JpaRepository<Vote, Long>, VoteRepositoryForCursor {
 }

--- a/src/main/java/com/programmers/bucketback/domains/vote/repository/VoteRepository.java
+++ b/src/main/java/com/programmers/bucketback/domains/vote/repository/VoteRepository.java
@@ -4,5 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.programmers.bucketback.domains.vote.domain.Vote;
 
-public interface VoteReposiory extends JpaRepository<Vote, Long> {
+public interface VoteRepository extends JpaRepository<Vote, Long> {
 }

--- a/src/main/java/com/programmers/bucketback/domains/vote/repository/VoteRepositoryForCursor.java
+++ b/src/main/java/com/programmers/bucketback/domains/vote/repository/VoteRepositoryForCursor.java
@@ -1,0 +1,19 @@
+package com.programmers.bucketback.domains.vote.repository;
+
+import java.util.List;
+
+import com.programmers.bucketback.domains.common.Hobby;
+import com.programmers.bucketback.domains.vote.application.VoteSortCondition;
+import com.programmers.bucketback.domains.vote.application.VoteStatusCondition;
+import com.programmers.bucketback.domains.vote.application.VoteSummary;
+
+public interface VoteRepositoryForCursor {
+	List<VoteSummary> findAllByCursor(
+		final Hobby hobby,
+		final VoteStatusCondition statusCondition,
+		final VoteSortCondition sortCondition,
+		final Long memberId,
+		final String nextCursorId,
+		final int pageSize
+	);
+}

--- a/src/main/java/com/programmers/bucketback/domains/vote/repository/VoteRepositoryForCursorImpl.java
+++ b/src/main/java/com/programmers/bucketback/domains/vote/repository/VoteRepositoryForCursorImpl.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import com.programmers.bucketback.domains.common.Hobby;
+import com.programmers.bucketback.domains.vote.application.VoteInfo;
 import com.programmers.bucketback.domains.vote.application.VoteSortCondition;
 import com.programmers.bucketback.domains.vote.application.VoteStatusCondition;
 import com.programmers.bucketback.domains.vote.application.VoteSummary;
@@ -38,7 +39,15 @@ public class VoteRepositoryForCursorImpl implements VoteRepositoryForCursor {
 	) {
 		return jpaQueryFactory
 			.select(Projections.constructor(VoteSummary.class,
-				vote,
+				Projections.constructor(VoteInfo.class,
+					vote.id,
+					vote.content,
+					vote.startTime,
+					vote.endTime,
+					vote.voters.size()
+				),
+				vote.option1ItemId,
+				vote.option2ItemId,
 				generateCursorId(sortCondition)
 			))
 			.from(vote)

--- a/src/main/java/com/programmers/bucketback/domains/vote/repository/VoteRepositoryForCursorImpl.java
+++ b/src/main/java/com/programmers/bucketback/domains/vote/repository/VoteRepositoryForCursorImpl.java
@@ -81,19 +81,11 @@ public class VoteRepositoryForCursorImpl implements VoteRepositoryForCursor {
 		return vote.endTime.before(LocalDateTime.now());
 	}
 
-	private BooleanExpression isPosted(Long memberId) {
-		if (memberId == null) {
-			memberId = 0L;
-		}
-
+	private BooleanExpression isPosted(final Long memberId) {
 		return vote.memberId.eq(memberId);
 	}
 
-	private BooleanExpression isParticipatedIn(Long memberId) {
-		if (memberId == null) {
-			memberId = 0L;
-		}
-
+	private BooleanExpression isParticipatedIn(final Long memberId) {
 		return vote.voters.any()
 			.memberId.eq(memberId);
 	}

--- a/src/main/java/com/programmers/bucketback/domains/vote/repository/VoteRepositoryForCursorImpl.java
+++ b/src/main/java/com/programmers/bucketback/domains/vote/repository/VoteRepositoryForCursorImpl.java
@@ -1,0 +1,133 @@
+package com.programmers.bucketback.domains.vote.repository;
+
+import static com.programmers.bucketback.domains.vote.domain.QVote.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.programmers.bucketback.domains.common.Hobby;
+import com.programmers.bucketback.domains.vote.application.VoteSortCondition;
+import com.programmers.bucketback.domains.vote.application.VoteStatusCondition;
+import com.programmers.bucketback.domains.vote.application.VoteSummary;
+import com.querydsl.core.types.ConstantImpl;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.StringExpression;
+import com.querydsl.core.types.dsl.StringExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class VoteRepositoryForCursorImpl implements VoteRepositoryForCursor {
+
+	private final JPAQueryFactory jpaQueryFactory;
+
+	@Override
+	public List<VoteSummary> findAllByCursor(
+		final Hobby hobby,
+		final VoteStatusCondition statusCondition,
+		final VoteSortCondition sortCondition,
+		final Long memberId,
+		final String nextCursorId,
+		final int pageSize
+	) {
+		return jpaQueryFactory
+			.select(Projections.constructor(VoteSummary.class,
+				vote,
+				generateCursorId(sortCondition)
+			))
+			.from(vote)
+			.where(
+				vote.hobby.eq(hobby),
+				getExpressionBy(statusCondition, memberId),
+				lessThanNextCursorId(sortCondition, nextCursorId)
+			)
+			.orderBy(getOrderSpecifierBy(sortCondition),
+				vote.id.desc())
+			.limit(pageSize)
+			.fetch();
+	}
+
+	private BooleanExpression getExpressionBy(
+		final VoteStatusCondition statusCondition,
+		final Long memberId
+	) {
+		if (statusCondition == VoteStatusCondition.INPROGRESS) {
+			return isInProgress();
+		}
+		if (statusCondition == VoteStatusCondition.COMPLETED) {
+			return isCompleted();
+		}
+		if (statusCondition == VoteStatusCondition.POSTED) {
+			return isPosted(memberId);
+		}
+		if (statusCondition == VoteStatusCondition.PARTICIPATED) {
+			return isParticipatedIn(memberId);
+		}
+
+		return null;
+	}
+
+	private BooleanExpression isInProgress() {
+		return vote.endTime.after(LocalDateTime.now());
+	}
+
+	private BooleanExpression isCompleted() {
+		return vote.endTime.before(LocalDateTime.now());
+	}
+
+	private BooleanExpression isPosted(Long memberId) {
+		if (memberId == null) {
+			memberId = 0L;
+		}
+
+		return vote.memberId.eq(memberId);
+	}
+
+	private BooleanExpression isParticipatedIn(Long memberId) {
+		if (memberId == null) {
+			memberId = 0L;
+		}
+
+		return vote.voters.any().memberId.eq(memberId);
+	}
+
+	private OrderSpecifier<?> getOrderSpecifierBy(final VoteSortCondition sortCondition) {
+		if (sortCondition == VoteSortCondition.POPULARITY) {
+			return new OrderSpecifier<>(Order.DESC, vote.voters.size());
+		}
+
+		return new OrderSpecifier<>(Order.DESC, vote.createdAt);
+	}
+
+	private BooleanExpression lessThanNextCursorId(
+		final VoteSortCondition sortCondition,
+		final String nextCursorId
+	) {
+		if (nextCursorId == null) {
+			return null;
+		}
+
+		return generateCursorId(sortCondition).lt(nextCursorId);
+	}
+
+	private StringExpression generateCursorId(final VoteSortCondition sortCondition) {
+		if (sortCondition == VoteSortCondition.POPULARITY) {
+			return StringExpressions.lpad(
+				vote.voters.size().stringValue(), 8, '0'
+			).concat(StringExpressions.lpad(
+				vote.id.stringValue(), 8, '0'
+			));
+		}
+
+		return Expressions.stringTemplate(
+			"DATE_FORMAT({0}, {1})", vote.createdAt, ConstantImpl.create("%Y%m%d%H%i%s")
+		).concat(StringExpressions.lpad(
+			vote.id.stringValue(), 8, '0'
+		));
+	}
+}

--- a/src/main/java/com/programmers/bucketback/domains/vote/repository/VoteRepositoryForCursorImpl.java
+++ b/src/main/java/com/programmers/bucketback/domains/vote/repository/VoteRepositoryForCursorImpl.java
@@ -15,6 +15,7 @@ import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.core.types.dsl.StringExpression;
 import com.querydsl.core.types.dsl.StringExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -93,7 +94,8 @@ public class VoteRepositoryForCursorImpl implements VoteRepositoryForCursor {
 			memberId = 0L;
 		}
 
-		return vote.voters.any().memberId.eq(memberId);
+		return vote.voters.any()
+			.memberId.eq(memberId);
 	}
 
 	private OrderSpecifier<?> getOrderSpecifierBy(final VoteSortCondition sortCondition) {
@@ -117,8 +119,10 @@ public class VoteRepositoryForCursorImpl implements VoteRepositoryForCursor {
 
 	private StringExpression generateCursorId(final VoteSortCondition sortCondition) {
 		if (sortCondition == VoteSortCondition.POPULARITY) {
+			final NumberExpression<Integer> popularity = vote.voters.size();
+
 			return StringExpressions.lpad(
-				vote.voters.size().stringValue(), 8, '0'
+				popularity.stringValue(), 8, '0'
 			).concat(StringExpressions.lpad(
 				vote.id.stringValue(), 8, '0'
 			));

--- a/src/main/java/com/programmers/bucketback/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/programmers/bucketback/global/error/exception/ErrorCode.java
@@ -34,6 +34,7 @@ public enum ErrorCode {
 	VOTE_NOT_CONTAIN_ITEM("VOTE_002", "투표에 포함된 아이템이 아닙니다."),
 	VOTE_NOT_OWNER("VOTE_003", "투표의 작성자가 아닙니다."),
 	VOTE_NOT_VOTER("VOTE_004", "투표의 투표자가 아닙니다."),
+	VOTE_BAD_POPULARITY("VOTE_005", "종료된 투표만 인기순 조회가 가능합니다."),
 
 	//Bucket
 	BUCKET_NOT_FOUND("BUCKET_001", "버킷을 찾을 수 없습니다."),
@@ -42,12 +43,11 @@ public enum ErrorCode {
 	// MemberItem
 	MEMBER_ITEM_NOT_FOUND("MEMBER_ITEM_001", "나의 아이템을 찾을 수 없습니다."),
 	MEMBER_NOT_MINE("MEMBER_ITEM_002", "아이템 담기에 없는 아이템 입니다."),
-	
+
 	//Inventory
 	INVENTORY_NOT_FOUND("INVENTORY_001", "인벤토리를 찾을 수 없습니다."),
-	INVENTORY_ALREADY_EXIST("INVENTORY_002", "이미 생성된인벤토리가 잇습니다.")
-	;
-	
+	INVENTORY_ALREADY_EXIST("INVENTORY_002", "이미 생성된인벤토리가 잇습니다.");
+
 	private final String code;
 	private final String message;
 }


### PR DESCRIPTION
## 📌 PR 종류

어떤 종류의 PR인지 아래 항목 중에 체크 해주세요.
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [ ]  🐛 버그 수정
- [x]  ✨ 기능 추가
- [ ]  **✅** 테스트 추가
- [ ]  🎨 코드 스타일 변경 (formatting, local variables)
- [ ]  🔨 리팩토링 (기능 변경 X)
- [ ]  **💚** 빌드 관련 수정
- [ ]  **📝** 문서 내용 수정
- [ ]  그 외, 어떤 종류인지 기입 바람:
<br>

## 📌 어떤 기능이 추가 되었나요?

<!--어떤 기능이 추가 되었는지 설명해주시고 관련된 지라 이슈 넘버를 추가 해주세요 -->

### Issue Number

OMCT-95

### 기능 설명

- 투표는 `진행 중인 투표`, `종료된 투표`, `내가 올린 투표`, `내가 참여한 투표` 4개의 목록을 조회할 수 있습니다.
- 위 4개의 목록은 기본적으로 최신순으로 정렬되며, 종료된 투표는 추가적으로 인기순으로 정렬될 수 있습니다.
- 인기순은 투표 참여자 수가 많은 순이며, 커서 ID는 참여자 수 + 투표 ID 두 개를 조합해서 생성하고 있습니다. 이 부분에 대해 문제가 있는데 아래 [고려해야 할 포인트]에서 설명하겠습니다.

### Query Parameter

이름 | 설명
-- | --
sortCondition | 정렬 기준(인기순, 최신순)
statusCondition | 투표 상태(진행중, 종료된,내가 올린, 내가 참여한)(필수)
hobby | 취미(필수)
cursorId | 커서ID
size | 페이지 사이즈

### 이전 커서 방식과 다른 점

- 이전에 구현된 커서를 보면 Querydsl 내부에서 cursorId를 생성하여 비교하고, 구현 계층에서도 cursorId를 다시 계산해주는 것으로 압니다.
- 위의 부분을 개선하기 위해서 Querydsl에서 생성한 cursorId도 결괏값으로 함께 반환해주어 구현 계층에서는 cursorId를 계산할 필요가 없졌습니다.

### 고려해야 할 포인트

- 현재 종료된 투표에서 **인기순** 조회는 투표 **참여자 수가 많은 순**으로 정렬이 됩니다. 따라서 커서 ID가 참여자 수와 투표 ID 를 통해 생성이 되는데 문제는 **참여자 수가 실시간으로 변하는 값**이라는 것 입니다. 참여자 수가 실시간으로 변하기 때문에 조회를 할 때 데이터가 누실될 경우가 있을 수 있습니다.
- 예를 들어, 인기순으로 10개의 투표를 조회한다고 가정해보겠습니다. 처음 투표 목록을 조회할 때, 인기순 10번째 투표의 참여자 수가 20이었고, 11번째 투표의 참여자 수가 19 였습니다. 그리고 nextCursor로 그 다음 페이지를 조회할 때 원래같으면 11번째 투표가 포함되어야 하는데 그 사이 11번째 투표의 참여자 수가 급증해서 20 이상이 되는 경우에는 기존 인기순 11번째 투표가 조회 결과에 포함되지 않을 것 입니다.
- 위의 문제에 대해서 다같이 의논해보면 좋을 것 같습니다!

<br>

## 📌 기존에 있던 기능에 영향을 주나요?

- [x]  네
- [ ]  아니요

<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->
- 커서 정보를 받는 DTO에서 page를 int에서 Integer로 바꿔주었습니다. 따라서 이전에 구현된 모든 커서 페이지네이션에 page 부분을 변경해야 할 것 같습니다.