### PR TITLE
NO-ZIRA: 아이템 상세조회 및 리뷰 평점 버그 수정

### DIFF
--- a/src/main/java/com/programmers/bucketback/domains/review/api/dto/request/ReviewCreateRequest.java
+++ b/src/main/java/com/programmers/bucketback/domains/review/api/dto/request/ReviewCreateRequest.java
@@ -2,11 +2,15 @@ package com.programmers.bucketback.domains.review.api.dto.request;
 
 import com.programmers.bucketback.domains.review.application.dto.ReviewContent;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 public record ReviewCreateRequest(
 
 	@NotNull
+	@Min(1)
+	@Max(5)
 	Integer rating,
 
 	String content

--- a/src/main/java/com/programmers/bucketback/domains/review/api/dto/request/ReviewUpdateRequest.java
+++ b/src/main/java/com/programmers/bucketback/domains/review/api/dto/request/ReviewUpdateRequest.java
@@ -2,11 +2,15 @@ package com.programmers.bucketback.domains.review.api.dto.request;
 
 import com.programmers.bucketback.domains.review.application.dto.ReviewContent;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 public record ReviewUpdateRequest(
 
 	@NotNull
+	@Min(1)
+	@Max(5)
 	Integer rating,
 
 	String content

--- a/src/main/java/com/programmers/bucketback/domains/review/application/ReviewStatistics.java
+++ b/src/main/java/com/programmers/bucketback/domains/review/application/ReviewStatistics.java
@@ -11,8 +11,8 @@ import lombok.RequiredArgsConstructor;
 public class ReviewStatistics {
 
 	private final ReviewRepository reviewRepository;
-	
-	public double getReviewAvgByItemId(final Long itemId) {
+
+	public Double getReviewAvgByItemId(final Long itemId) {
 		return reviewRepository.getAvgRatingByReviewId(itemId);
 	}
 }

--- a/src/main/java/com/programmers/bucketback/domains/review/repository/ReviewRepository.java
+++ b/src/main/java/com/programmers/bucketback/domains/review/repository/ReviewRepository.java
@@ -11,7 +11,7 @@ import com.programmers.bucketback.domains.review.domain.Review;
 public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewRepositoryForCursor {
 
 	@Query("SELECT ROUND(AVG(r.rating), 1) FROM Review r WHERE r.itemId = :itemId")
-	double getAvgRatingByReviewId(@Param("itemId") Long itemId);
+	Double getAvgRatingByReviewId(@Param("itemId") Long itemId);
 
 	List<Review> findByMemberId(Long memberId);
 }


### PR DESCRIPTION
## 📌 PR 종류

어떤 종류의 PR인지 아래 항목 중에 체크 해주세요.
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [x]  🐛 버그 수정
- [ ]  ✨ 기능 추가
- [ ]  **✅** 테스트 추가
- [ ]  🎨 코드 스타일 변경 (formatting, local variables)
- [ ]  🔨 리팩토링 (기능 변경 X)
- [ ]  **💚** 빌드 관련 수정
- [ ]  **📝** 문서 내용 수정
- [ ]  그 외, 어떤 종류인지 기입 바람:
<br>

## 📌 어떤 기능이 추가 되었나요?

<!--어떤 기능이 추가 되었는지 설명해주시고 관련된 지라 이슈 넘버를 추가 해주세요 -->

### Issue Number

N/A

### 기능 설명

#### 리뷰 평점 최소 최대 제한 추가
#### 아이템 상세조회 할 때 리뷰가 없는 경우 예외가 발생하는 버그 수정

#### 버그 발생이유
- jpql 집계함수에서 item id가 리뷰 테이블에 없는 경우 null을 반환한다.
- 이 때 반환 타입이 double 이라 초기화 하지 못해 예외가 발상하였다.

#### 해결
- double 대신 Double 타입으로 변경하고 null을 반환하도록 수정하였다. 
- 추후에 프론트와 의논하여 값을 내려주지 않을지 지금처럼 null을 반환할지 의논할 예정이다. 

## 📌 기존에 있던 기능에 영향을 주나요?

- [ ]  네
- [ ]  아니요

<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->
