### PR TITLE
[NO-JIRA] VO 추출로 인한 커서 목록 조회 안되는 버그 해결

### DIFF
--- a/src/main/java/com/programmers/bucketback/domains/comment/repository/CommentRepositoryForCursorImpl.java
+++ b/src/main/java/com/programmers/bucketback/domains/comment/repository/CommentRepositoryForCursorImpl.java
@@ -1,24 +1,19 @@
 package com.programmers.bucketback.domains.comment.repository;
 
-import static com.programmers.bucketback.domains.comment.domain.QComment.*;
-import static com.programmers.bucketback.domains.member.domain.QMember.*;
-
-import java.time.LocalDateTime;
-import java.util.List;
-
 import com.programmers.bucketback.domains.member.application.vo.MemberInfo;
 import com.querydsl.core.types.ConstantImpl;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
-import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.Expressions;
-import com.querydsl.core.types.dsl.StringExpression;
-import com.querydsl.core.types.dsl.StringExpressions;
-import com.querydsl.core.types.dsl.StringTemplate;
+import com.querydsl.core.types.dsl.*;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-
 import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.programmers.bucketback.domains.comment.domain.QComment.comment;
+import static com.programmers.bucketback.domains.member.domain.QMember.member;
 
 @RequiredArgsConstructor
 public class CommentRepositoryForCursorImpl implements CommentRepositoryForCursor {
@@ -40,12 +35,12 @@ public class CommentRepositoryForCursorImpl implements CommentRepositoryForCurso
 					Projections.constructor(
 						MemberInfo.class,
 						member.id,
-						member.nickname,
-						member.introduction,//프로필이미지 대신 임시로 사용 : 프로필 이미지 필드 생기면 추가
+						member.nickname.nickname,
+						member.introduction.introduction,//프로필이미지 대신 임시로 사용 : 프로필 이미지 필드 생기면 추가
 						member.levelPoint
 					),
 					comment.id,
-					comment.content,
+					comment.content.content,
 					comment.adoption,
 					comment.createdAt
 				)

--- a/src/main/java/com/programmers/bucketback/domains/feed/repository/FeedRepositoryForCursorImpl.java
+++ b/src/main/java/com/programmers/bucketback/domains/feed/repository/FeedRepositoryForCursorImpl.java
@@ -1,13 +1,5 @@
 package com.programmers.bucketback.domains.feed.repository;
 
-import static com.programmers.bucketback.domains.feed.domain.QFeed.*;
-import static com.programmers.bucketback.domains.feed.domain.QFeedItem.*;
-import static com.programmers.bucketback.domains.member.domain.QMember.*;
-import static com.querydsl.core.group.GroupBy.*;
-
-import java.util.List;
-import java.util.Objects;
-
 import com.programmers.bucketback.domains.common.Hobby;
 import com.programmers.bucketback.domains.feed.application.FeedSortCondition;
 import com.programmers.bucketback.domains.feed.application.vo.FeedCursorItem;
@@ -17,14 +9,18 @@ import com.querydsl.core.types.ConstantImpl;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
-import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.Expressions;
-import com.querydsl.core.types.dsl.NumberExpression;
-import com.querydsl.core.types.dsl.StringExpression;
-import com.querydsl.core.types.dsl.StringExpressions;
+import com.querydsl.core.types.dsl.*;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-
 import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+import java.util.Objects;
+
+import static com.programmers.bucketback.domains.feed.domain.QFeed.feed;
+import static com.programmers.bucketback.domains.feed.domain.QFeedItem.feedItem;
+import static com.programmers.bucketback.domains.member.domain.QMember.member;
+import static com.querydsl.core.group.GroupBy.groupBy;
+import static com.querydsl.core.group.GroupBy.list;
 
 @RequiredArgsConstructor
 public class FeedRepositoryForCursorImpl implements FeedRepositoryForCursor {
@@ -63,7 +59,7 @@ public class FeedRepositoryForCursorImpl implements FeedRepositoryForCursor {
 							Projections.constructor(
 								MemberInfo.class,
 								member.id,
-								member.nickname
+								member.nickname.nickname
 							),
 							feedItem.feed.id,
 							feedItem.feed.message,

--- a/src/main/java/com/programmers/bucketback/domains/review/repository/ReviewRepositoryForCursorImpl.java
+++ b/src/main/java/com/programmers/bucketback/domains/review/repository/ReviewRepositoryForCursorImpl.java
@@ -1,25 +1,20 @@
 package com.programmers.bucketback.domains.review.repository;
 
-import static com.programmers.bucketback.domains.member.domain.QMember.*;
-import static com.programmers.bucketback.domains.review.domain.QReview.*;
-
-import java.time.LocalDateTime;
-import java.util.List;
-
 import com.programmers.bucketback.domains.member.application.vo.MemberInfo;
 import com.programmers.bucketback.domains.review.application.vo.ReviewCursorSummary;
 import com.querydsl.core.types.ConstantImpl;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
-import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.Expressions;
-import com.querydsl.core.types.dsl.StringExpression;
-import com.querydsl.core.types.dsl.StringExpressions;
-import com.querydsl.core.types.dsl.StringTemplate;
+import com.querydsl.core.types.dsl.*;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-
 import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.programmers.bucketback.domains.member.domain.QMember.member;
+import static com.programmers.bucketback.domains.review.domain.QReview.review;
 
 @RequiredArgsConstructor
 public class ReviewRepositoryForCursorImpl implements ReviewRepositoryForCursor {
@@ -40,7 +35,7 @@ public class ReviewRepositoryForCursorImpl implements ReviewRepositoryForCursor 
 					Projections.constructor(
 						MemberInfo.class,
 						member.id,
-						member.nickname
+						member.nickname.nickname
 					),
 					review.id,
 					review.rating,

--- a/src/main/java/com/programmers/bucketback/domains/vote/repository/VoteRepositoryForCursorImpl.java
+++ b/src/main/java/com/programmers/bucketback/domains/vote/repository/VoteRepositoryForCursorImpl.java
@@ -1,10 +1,5 @@
 package com.programmers.bucketback.domains.vote.repository;
 
-import static com.programmers.bucketback.domains.vote.domain.QVote.*;
-
-import java.time.LocalDateTime;
-import java.util.List;
-
 import com.programmers.bucketback.domains.common.Hobby;
 import com.programmers.bucketback.domains.vote.application.dto.request.VoteSortCondition;
 import com.programmers.bucketback.domains.vote.application.dto.request.VoteStatusCondition;
@@ -14,14 +9,14 @@ import com.querydsl.core.types.ConstantImpl;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
-import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.Expressions;
-import com.querydsl.core.types.dsl.NumberExpression;
-import com.querydsl.core.types.dsl.StringExpression;
-import com.querydsl.core.types.dsl.StringExpressions;
+import com.querydsl.core.types.dsl.*;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-
 import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.programmers.bucketback.domains.vote.domain.QVote.vote;
 
 @RequiredArgsConstructor
 public class VoteRepositoryForCursorImpl implements VoteRepositoryForCursor {
@@ -41,7 +36,7 @@ public class VoteRepositoryForCursorImpl implements VoteRepositoryForCursor {
 			.select(Projections.constructor(VoteSummary.class,
 				Projections.constructor(VoteInfo.class,
 					vote.id,
-					vote.content,
+					vote.content.content,
 					vote.startTime,
 					vote.endTime,
 					vote.voters.size()


### PR DESCRIPTION
## 📌 PR 종류

어떤 종류의 PR인지 아래 항목 중에 체크 해주세요.
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [x]  🐛 버그 수정
- [ ]  ✨ 기능 추가
- [ ]  **✅** 테스트 추가
- [ ]  🎨 코드 스타일 변경 (formatting, local variables)
- [ ]  🔨 리팩토링 (기능 변경 X)
- [ ]  **💚** 빌드 관련 수정
- [ ]  **📝** 문서 내용 수정
- [ ]  그 외, 어떤 종류인지 기입 바람:
<br>

## 📌 어떤 기능이 추가 되었나요?

<!--어떤 기능이 추가 되었는지 설명해주시고 관련된 지라 이슈 넘버를 추가 해주세요 -->

### Issue Number

NO-JIRA

### 기능 설명

- Nickname과 같은 VO를 추출하면서 기존의 Querydsl을 사용하면 조회가 안되는 문제가 발생했습니다.
- `member.nickname` -> `member.nickname.nickname` 과 같이 중간에 추출한 VO 클래스명을 추가하여 해결하였습니다.

<br>

## 📌 기존에 있던 기능에 영향을 주나요?

- [ ]  네
- [x]  아니요

<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->
