### PR TITLE
[OMCT-247] 멀티모듈을 위한 error 패키지 리팩토링

### DIFF
--- a/api/src/main/java/com/programmers/bucketback/domains/bucket/application/BucketService.java
+++ b/api/src/main/java/com/programmers/bucketback/domains/bucket/application/BucketService.java
@@ -16,8 +16,8 @@ import com.programmers.bucketback.domains.bucket.model.BucketSummary;
 import com.programmers.bucketback.domains.bucket.model.ItemIdRegistry;
 import com.programmers.bucketback.domains.item.implementation.ItemReader;
 import com.programmers.bucketback.domains.member.implementation.MemberReader;
-import com.programmers.bucketback.error.exception.BusinessException;
-import com.programmers.bucketback.error.exception.ErrorCode;
+import com.programmers.bucketback.error.BusinessException;
+import com.programmers.bucketback.error.ErrorCode;
 import com.programmers.bucketback.global.util.MemberUtils;
 
 import lombok.RequiredArgsConstructor;

--- a/api/src/main/java/com/programmers/bucketback/domains/comment/application/CommentService.java
+++ b/api/src/main/java/com/programmers/bucketback/domains/comment/application/CommentService.java
@@ -12,8 +12,8 @@ import com.programmers.bucketback.domains.comment.implementation.CommentReader;
 import com.programmers.bucketback.domains.comment.implementation.CommentRemover;
 import com.programmers.bucketback.domains.feed.domain.Feed;
 import com.programmers.bucketback.domains.feed.implementation.FeedReader;
-import com.programmers.bucketback.error.exception.BusinessException;
-import com.programmers.bucketback.error.exception.ErrorCode;
+import com.programmers.bucketback.error.BusinessException;
+import com.programmers.bucketback.error.ErrorCode;
 import com.programmers.bucketback.global.level.PayPoint;
 import com.programmers.bucketback.global.util.MemberUtils;
 

--- a/api/src/main/java/com/programmers/bucketback/domains/comment/application/CommentValidator.java
+++ b/api/src/main/java/com/programmers/bucketback/domains/comment/application/CommentValidator.java
@@ -4,8 +4,8 @@ import org.springframework.stereotype.Component;
 
 import com.programmers.bucketback.domains.comment.domain.Comment;
 import com.programmers.bucketback.domains.comment.implementation.CommentReader;
-import com.programmers.bucketback.error.exception.BusinessException;
-import com.programmers.bucketback.error.exception.ErrorCode;
+import com.programmers.bucketback.error.BusinessException;
+import com.programmers.bucketback.error.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
 

--- a/api/src/main/java/com/programmers/bucketback/domains/inventory/application/InventoryService.java
+++ b/api/src/main/java/com/programmers/bucketback/domains/inventory/application/InventoryService.java
@@ -16,8 +16,8 @@ import com.programmers.bucketback.domains.inventory.model.InventoryGetServiceRes
 import com.programmers.bucketback.domains.inventory.model.InventoryInfoSummary;
 import com.programmers.bucketback.domains.inventory.model.InventoryReviewItemSummary;
 import com.programmers.bucketback.domains.member.implementation.MemberReader;
-import com.programmers.bucketback.error.exception.BusinessException;
-import com.programmers.bucketback.error.exception.ErrorCode;
+import com.programmers.bucketback.error.BusinessException;
+import com.programmers.bucketback.error.ErrorCode;
 import com.programmers.bucketback.global.util.MemberUtils;
 
 import lombok.RequiredArgsConstructor;

--- a/api/src/main/java/com/programmers/bucketback/domains/item/application/ItemEnrollValidator.java
+++ b/api/src/main/java/com/programmers/bucketback/domains/item/application/ItemEnrollValidator.java
@@ -3,8 +3,8 @@ package com.programmers.bucketback.domains.item.application;
 import org.springframework.stereotype.Component;
 
 import com.programmers.bucketback.domains.item.repository.ItemRepository;
-import com.programmers.bucketback.error.exception.BusinessException;
-import com.programmers.bucketback.error.exception.ErrorCode;
+import com.programmers.bucketback.error.BusinessException;
+import com.programmers.bucketback.error.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
 

--- a/api/src/main/java/com/programmers/bucketback/domains/member/application/MemberService.java
+++ b/api/src/main/java/com/programmers/bucketback/domains/member/application/MemberService.java
@@ -11,8 +11,8 @@ import com.programmers.bucketback.domains.member.implementation.MemberModifier;
 import com.programmers.bucketback.domains.member.implementation.MemberReader;
 import com.programmers.bucketback.domains.member.implementation.MemberRemover;
 import com.programmers.bucketback.domains.member.model.MyPage;
-import com.programmers.bucketback.error.exception.BusinessException;
-import com.programmers.bucketback.error.exception.ErrorCode;
+import com.programmers.bucketback.error.BusinessException;
+import com.programmers.bucketback.error.ErrorCode;
 import com.programmers.bucketback.global.util.MemberUtils;
 import com.programmers.bucketback.mail.EmailSender;
 

--- a/api/src/main/java/com/programmers/bucketback/domains/review/application/ReviewValidator.java
+++ b/api/src/main/java/com/programmers/bucketback/domains/review/application/ReviewValidator.java
@@ -4,8 +4,8 @@ import org.springframework.stereotype.Component;
 
 import com.programmers.bucketback.domains.review.domain.Review;
 import com.programmers.bucketback.domains.review.implementation.ReviewReader;
-import com.programmers.bucketback.error.exception.BusinessException;
-import com.programmers.bucketback.error.exception.ErrorCode;
+import com.programmers.bucketback.error.BusinessException;
+import com.programmers.bucketback.error.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
 

--- a/api/src/main/java/com/programmers/bucketback/domains/vote/application/VoteService.java
+++ b/api/src/main/java/com/programmers/bucketback/domains/vote/application/VoteService.java
@@ -15,8 +15,8 @@ import com.programmers.bucketback.domains.vote.implementation.VoteRemover;
 import com.programmers.bucketback.domains.vote.model.VoteSortCondition;
 import com.programmers.bucketback.domains.vote.model.VoteStatusCondition;
 import com.programmers.bucketback.domains.vote.model.VoteSummary;
-import com.programmers.bucketback.error.exception.BusinessException;
-import com.programmers.bucketback.error.exception.ErrorCode;
+import com.programmers.bucketback.error.BusinessException;
+import com.programmers.bucketback.error.ErrorCode;
 import com.programmers.bucketback.global.util.MemberUtils;
 
 import lombok.RequiredArgsConstructor;

--- a/api/src/main/java/com/programmers/bucketback/global/config/security/SecurityUtils.java
+++ b/api/src/main/java/com/programmers/bucketback/global/config/security/SecurityUtils.java
@@ -4,8 +4,8 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 
-import com.programmers.bucketback.error.exception.BusinessException;
-import com.programmers.bucketback.error.exception.ErrorCode;
+import com.programmers.bucketback.error.BusinessException;
+import com.programmers.bucketback.error.ErrorCode;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;

--- a/api/src/main/java/com/programmers/bucketback/global/error/ErrorResponse.java
+++ b/api/src/main/java/com/programmers/bucketback/global/error/ErrorResponse.java
@@ -1,4 +1,4 @@
-package com.programmers.bucketback.error;
+package com.programmers.bucketback.global.error;
 
 import java.util.List;
 import java.util.stream.Collectors;

--- a/api/src/main/java/com/programmers/bucketback/global/error/ErrorResponse.java
+++ b/api/src/main/java/com/programmers/bucketback/global/error/ErrorResponse.java
@@ -7,7 +7,7 @@ import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.programmers.bucketback.error.exception.ErrorCode;
+import com.programmers.bucketback.error.ErrorCode;
 
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/api/src/main/java/com/programmers/bucketback/global/error/GlobalExceptionHandler.java
+++ b/api/src/main/java/com/programmers/bucketback/global/error/GlobalExceptionHandler.java
@@ -1,4 +1,4 @@
-package com.programmers.bucketback.error;
+package com.programmers.bucketback.global.error;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/api/src/main/java/com/programmers/bucketback/global/error/GlobalExceptionHandler.java
+++ b/api/src/main/java/com/programmers/bucketback/global/error/GlobalExceptionHandler.java
@@ -14,7 +14,6 @@ import com.programmers.bucketback.error.exception.EntityNotFoundException;
 import com.programmers.bucketback.error.exception.ErrorCode;
 
 import io.jsonwebtoken.ExpiredJwtException;
-import jakarta.mail.MessagingException;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -50,14 +49,6 @@ public class GlobalExceptionHandler {
 		final ErrorResponse response = ErrorResponse.from(ErrorCode.MEMBER_LOGIN_FAIL);
 
 		return new ResponseEntity<>(response, HttpStatus.UNAUTHORIZED);
-	}
-
-	@ExceptionHandler(MessagingException.class)
-	protected ResponseEntity<ErrorResponse> handleMessagingException(final MessagingException e) {
-		log.error("MessagingException", e);
-		final ErrorResponse response = ErrorResponse.from(ErrorCode.MAIL_SEND_FAIL);
-
-		return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
 	}
 
 	@ExceptionHandler(MissingServletRequestParameterException.class)

--- a/api/src/main/java/com/programmers/bucketback/global/error/GlobalExceptionHandler.java
+++ b/api/src/main/java/com/programmers/bucketback/global/error/GlobalExceptionHandler.java
@@ -9,9 +9,9 @@ import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import com.programmers.bucketback.error.exception.BusinessException;
-import com.programmers.bucketback.error.exception.EntityNotFoundException;
-import com.programmers.bucketback.error.exception.ErrorCode;
+import com.programmers.bucketback.error.BusinessException;
+import com.programmers.bucketback.error.EntityNotFoundException;
+import com.programmers.bucketback.error.ErrorCode;
 
 import io.jsonwebtoken.ExpiredJwtException;
 import lombok.extern.slf4j.Slf4j;

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,13 +1,5 @@
-dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-validation'
+dependencies {\
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation 'org.springframework.boot:spring-boot-starter-mail'
-
-    // jwt
-    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
-    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
-    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 bootJar {

--- a/common/src/main/java/com/programmers/bucketback/Hobby.java
+++ b/common/src/main/java/com/programmers/bucketback/Hobby.java
@@ -9,8 +9,8 @@ import java.util.stream.Stream;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import com.programmers.bucketback.error.exception.BusinessException;
-import com.programmers.bucketback.error.exception.ErrorCode;
+import com.programmers.bucketback.error.BusinessException;
+import com.programmers.bucketback.error.ErrorCode;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/common/src/main/java/com/programmers/bucketback/error/BusinessException.java
+++ b/common/src/main/java/com/programmers/bucketback/error/BusinessException.java
@@ -1,4 +1,4 @@
-package com.programmers.bucketback.error.exception;
+package com.programmers.bucketback.error;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/common/src/main/java/com/programmers/bucketback/error/EntityNotFoundException.java
+++ b/common/src/main/java/com/programmers/bucketback/error/EntityNotFoundException.java
@@ -1,4 +1,4 @@
-package com.programmers.bucketback.error.exception;
+package com.programmers.bucketback.error;
 
 public class EntityNotFoundException extends BusinessException {
 	public EntityNotFoundException(final ErrorCode errorCode) {

--- a/common/src/main/java/com/programmers/bucketback/error/ErrorCode.java
+++ b/common/src/main/java/com/programmers/bucketback/error/ErrorCode.java
@@ -1,4 +1,4 @@
-package com.programmers.bucketback.error.exception;
+package com.programmers.bucketback.error;
 
 import java.util.Collections;
 import java.util.Map;

--- a/common/src/main/java/com/programmers/bucketback/error/GlobalExceptionHandler.java
+++ b/common/src/main/java/com/programmers/bucketback/error/GlobalExceptionHandler.java
@@ -26,9 +26,11 @@ public class GlobalExceptionHandler {
 		log.error("Error occurred", e);
 		final ErrorCode errorCode = ErrorCode.from(e.getMessage());
 		final ErrorResponse response = ErrorResponse.from(errorCode);
+
 		if (errorCode == ErrorCode.INTERNAL_SERVER_ERROR) {
 			return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
 		}
+
 		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
 	}
 
@@ -38,6 +40,7 @@ public class GlobalExceptionHandler {
 		log.error("MethodArgumentNotValidException Exception", e);
 		final BindingResult bindingResult = e.getBindingResult();
 		final ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_REQUEST, bindingResult);
+
 		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
 	}
 
@@ -45,6 +48,7 @@ public class GlobalExceptionHandler {
 	protected ResponseEntity<ErrorResponse> handleBadCredentialsException(final BadCredentialsException e) {
 		log.error("BadCredentialsException", e);
 		final ErrorResponse response = ErrorResponse.from(ErrorCode.MEMBER_LOGIN_FAIL);
+
 		return new ResponseEntity<>(response, HttpStatus.UNAUTHORIZED);
 	}
 
@@ -52,6 +56,7 @@ public class GlobalExceptionHandler {
 	protected ResponseEntity<ErrorResponse> handleMessagingException(final MessagingException e) {
 		log.error("MessagingException", e);
 		final ErrorResponse response = ErrorResponse.from(ErrorCode.MAIL_SEND_FAIL);
+
 		return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
 	}
 
@@ -60,6 +65,7 @@ public class GlobalExceptionHandler {
 		final MissingServletRequestParameterException e) {
 		log.error("MissingServletRequestParameterException", e);
 		final ErrorResponse response = ErrorResponse.from(ErrorCode.MISSING_PARAMETER);
+
 		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
 	}
 
@@ -67,6 +73,7 @@ public class GlobalExceptionHandler {
 	protected ResponseEntity<ErrorResponse> handleJwtException(final ExpiredJwtException e) {
 		log.error("ExpiredJwtException", e);
 		final ErrorResponse response = ErrorResponse.from(ErrorCode.EXPIRED_JWT);
+
 		return new ResponseEntity<>(response, HttpStatus.UNAUTHORIZED);
 	}
 
@@ -74,6 +81,7 @@ public class GlobalExceptionHandler {
 	protected ResponseEntity<ErrorResponse> handleBusinessException(final BusinessException e) {
 		log.error("BusinessException", e);
 		final ErrorResponse response = ErrorResponse.from(e.getErrorCode());
+
 		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
 	}
 
@@ -81,6 +89,7 @@ public class GlobalExceptionHandler {
 	protected ResponseEntity<ErrorResponse> handleEntityNotFoundException(final EntityNotFoundException e) {
 		log.error("EntityNotFoundException", e);
 		final ErrorResponse response = ErrorResponse.from(e.getErrorCode());
+
 		return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
 	}
 }

--- a/common/src/main/java/com/programmers/bucketback/error/GlobalExceptionHandler.java
+++ b/common/src/main/java/com/programmers/bucketback/error/GlobalExceptionHandler.java
@@ -23,9 +23,13 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(Exception.class)
 	protected ResponseEntity<ErrorResponse> handleException(final Exception e) {
-		log.error("UnExpected Exception", e);
-		final ErrorResponse response = ErrorResponse.from(ErrorCode.INTERNAL_SERVER_ERROR);
-		return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+		log.error("Error occurred", e);
+		final ErrorCode errorCode = ErrorCode.from(e.getMessage());
+		final ErrorResponse response = ErrorResponse.from(errorCode);
+		if (errorCode == ErrorCode.INTERNAL_SERVER_ERROR) {
+			return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+		}
+		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
 	}
 
 	@ExceptionHandler(MethodArgumentNotValidException.class)

--- a/common/src/main/java/com/programmers/bucketback/error/exception/ErrorCode.java
+++ b/common/src/main/java/com/programmers/bucketback/error/exception/ErrorCode.java
@@ -1,5 +1,11 @@
 package com.programmers.bucketback.error.exception;
 
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -93,6 +99,21 @@ public enum ErrorCode {
 	CRAWLER_COUPANG_BAD_REQUEST("CRAWLER", "쿠팡 크롤러에서 파싱할 수 없는 URL 입니다."),
 	CRAWLER_DANAWA_BAD_REQUEST("CRAWLER", "다나와 크롤러에서 파싱할 수 없는 URL 입니다.");
 
+	private static final Map<String, ErrorCode> ERROR_CODE_MAP;
+
+	static {
+		ERROR_CODE_MAP = Collections.unmodifiableMap(Stream.of(values())
+			.collect(Collectors.toMap(ErrorCode::getMessage, Function.identity())));
+	}
+
 	private final String code;
 	private final String message;
+
+	public static ErrorCode from(final String message) {
+		if (ERROR_CODE_MAP.containsKey(message)) {
+			return ERROR_CODE_MAP.get(message);
+		}
+
+		return ErrorCode.INTERNAL_SERVER_ERROR;
+	}
 }

--- a/domain/src/main/java/com/programmers/bucketback/domains/bucket/domain/BucketInfo.java
+++ b/domain/src/main/java/com/programmers/bucketback/domains/bucket/domain/BucketInfo.java
@@ -3,8 +3,8 @@ package com.programmers.bucketback.domains.bucket.domain;
 import java.util.Objects;
 
 import com.programmers.bucketback.Hobby;
-import com.programmers.bucketback.error.exception.BusinessException;
-import com.programmers.bucketback.error.exception.ErrorCode;
+import com.programmers.bucketback.error.BusinessException;
+import com.programmers.bucketback.error.ErrorCode;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;

--- a/domain/src/main/java/com/programmers/bucketback/domains/bucket/implementation/BucketReader.java
+++ b/domain/src/main/java/com/programmers/bucketback/domains/bucket/implementation/BucketReader.java
@@ -23,8 +23,8 @@ import com.programmers.bucketback.domains.item.domain.Item;
 import com.programmers.bucketback.domains.item.implementation.ItemReader;
 import com.programmers.bucketback.domains.item.implementation.MemberItemReader;
 import com.programmers.bucketback.domains.item.model.ItemInfo;
-import com.programmers.bucketback.error.exception.EntityNotFoundException;
-import com.programmers.bucketback.error.exception.ErrorCode;
+import com.programmers.bucketback.error.EntityNotFoundException;
+import com.programmers.bucketback.error.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
 

--- a/domain/src/main/java/com/programmers/bucketback/domains/comment/domain/vo/Content.java
+++ b/domain/src/main/java/com/programmers/bucketback/domains/comment/domain/vo/Content.java
@@ -1,7 +1,7 @@
 package com.programmers.bucketback.domains.comment.domain.vo;
 
-import com.programmers.bucketback.error.exception.BusinessException;
-import com.programmers.bucketback.error.exception.ErrorCode;
+import com.programmers.bucketback.error.BusinessException;
+import com.programmers.bucketback.error.ErrorCode;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;

--- a/domain/src/main/java/com/programmers/bucketback/domains/comment/implementation/CommentReader.java
+++ b/domain/src/main/java/com/programmers/bucketback/domains/comment/implementation/CommentReader.java
@@ -10,8 +10,8 @@ import com.programmers.bucketback.domains.comment.domain.Comment;
 import com.programmers.bucketback.domains.comment.model.CommentCursorSummary;
 import com.programmers.bucketback.domains.comment.repository.CommentRepository;
 import com.programmers.bucketback.domains.comment.repository.CommentSummary;
-import com.programmers.bucketback.error.exception.EntityNotFoundException;
-import com.programmers.bucketback.error.exception.ErrorCode;
+import com.programmers.bucketback.error.EntityNotFoundException;
+import com.programmers.bucketback.error.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
 

--- a/domain/src/main/java/com/programmers/bucketback/domains/feed/domain/FeedContent.java
+++ b/domain/src/main/java/com/programmers/bucketback/domains/feed/domain/FeedContent.java
@@ -1,7 +1,7 @@
 package com.programmers.bucketback.domains.feed.domain;
 
-import com.programmers.bucketback.error.exception.BusinessException;
-import com.programmers.bucketback.error.exception.ErrorCode;
+import com.programmers.bucketback.error.BusinessException;
+import com.programmers.bucketback.error.ErrorCode;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;

--- a/domain/src/main/java/com/programmers/bucketback/domains/feed/implementation/FeedAppender.java
+++ b/domain/src/main/java/com/programmers/bucketback/domains/feed/implementation/FeedAppender.java
@@ -16,8 +16,8 @@ import com.programmers.bucketback.domains.feed.repository.FeedLikeRepository;
 import com.programmers.bucketback.domains.feed.repository.FeedRepository;
 import com.programmers.bucketback.domains.item.domain.Item;
 import com.programmers.bucketback.domains.item.implementation.ItemReader;
-import com.programmers.bucketback.error.exception.BusinessException;
-import com.programmers.bucketback.error.exception.ErrorCode;
+import com.programmers.bucketback.error.BusinessException;
+import com.programmers.bucketback.error.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
 

--- a/domain/src/main/java/com/programmers/bucketback/domains/feed/implementation/FeedReader.java
+++ b/domain/src/main/java/com/programmers/bucketback/domains/feed/implementation/FeedReader.java
@@ -15,8 +15,8 @@ import com.programmers.bucketback.domains.feed.repository.FeedRepository;
 import com.programmers.bucketback.domains.member.domain.Member;
 import com.programmers.bucketback.domains.member.implementation.MemberReader;
 import com.programmers.bucketback.domains.member.model.MemberInfo;
-import com.programmers.bucketback.error.exception.EntityNotFoundException;
-import com.programmers.bucketback.error.exception.ErrorCode;
+import com.programmers.bucketback.error.EntityNotFoundException;
+import com.programmers.bucketback.error.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
 

--- a/domain/src/main/java/com/programmers/bucketback/domains/feed/implementation/FeedRemover.java
+++ b/domain/src/main/java/com/programmers/bucketback/domains/feed/implementation/FeedRemover.java
@@ -6,8 +6,8 @@ import org.springframework.transaction.annotation.Transactional;
 import com.programmers.bucketback.domains.feed.domain.Feed;
 import com.programmers.bucketback.domains.feed.repository.FeedLikeRepository;
 import com.programmers.bucketback.domains.feed.repository.FeedRepository;
-import com.programmers.bucketback.error.exception.BusinessException;
-import com.programmers.bucketback.error.exception.ErrorCode;
+import com.programmers.bucketback.error.BusinessException;
+import com.programmers.bucketback.error.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
 

--- a/domain/src/main/java/com/programmers/bucketback/domains/feed/model/FeedSortCondition.java
+++ b/domain/src/main/java/com/programmers/bucketback/domains/feed/model/FeedSortCondition.java
@@ -6,8 +6,8 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import com.programmers.bucketback.error.exception.BusinessException;
-import com.programmers.bucketback.error.exception.ErrorCode;
+import com.programmers.bucketback.error.BusinessException;
+import com.programmers.bucketback.error.ErrorCode;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/domain/src/main/java/com/programmers/bucketback/domains/inventory/implementation/InventoryReader.java
+++ b/domain/src/main/java/com/programmers/bucketback/domains/inventory/implementation/InventoryReader.java
@@ -25,8 +25,8 @@ import com.programmers.bucketback.domains.item.implementation.ItemReader;
 import com.programmers.bucketback.domains.item.model.ItemInfo;
 import com.programmers.bucketback.domains.review.domain.Review;
 import com.programmers.bucketback.domains.review.implementation.ReviewReader;
-import com.programmers.bucketback.error.exception.EntityNotFoundException;
-import com.programmers.bucketback.error.exception.ErrorCode;
+import com.programmers.bucketback.error.EntityNotFoundException;
+import com.programmers.bucketback.error.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
 

--- a/domain/src/main/java/com/programmers/bucketback/domains/item/implementation/ItemReader.java
+++ b/domain/src/main/java/com/programmers/bucketback/domains/item/implementation/ItemReader.java
@@ -8,8 +8,8 @@ import org.springframework.transaction.annotation.Transactional;
 import com.programmers.bucketback.domains.inventory.model.InventoryReviewItemSummary;
 import com.programmers.bucketback.domains.item.domain.Item;
 import com.programmers.bucketback.domains.item.repository.ItemRepository;
-import com.programmers.bucketback.error.exception.EntityNotFoundException;
-import com.programmers.bucketback.error.exception.ErrorCode;
+import com.programmers.bucketback.error.EntityNotFoundException;
+import com.programmers.bucketback.error.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
 

--- a/domain/src/main/java/com/programmers/bucketback/domains/item/implementation/MemberItemReader.java
+++ b/domain/src/main/java/com/programmers/bucketback/domains/item/implementation/MemberItemReader.java
@@ -9,8 +9,8 @@ import com.programmers.bucketback.domains.bucket.model.BucketMemberItemSummary;
 import com.programmers.bucketback.domains.item.domain.Item;
 import com.programmers.bucketback.domains.item.domain.MemberItem;
 import com.programmers.bucketback.domains.item.repository.MemberItemRepository;
-import com.programmers.bucketback.error.exception.EntityNotFoundException;
-import com.programmers.bucketback.error.exception.ErrorCode;
+import com.programmers.bucketback.error.EntityNotFoundException;
+import com.programmers.bucketback.error.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
 

--- a/domain/src/main/java/com/programmers/bucketback/domains/item/implementation/MemberItemValidator.java
+++ b/domain/src/main/java/com/programmers/bucketback/domains/item/implementation/MemberItemValidator.java
@@ -6,8 +6,8 @@ import org.springframework.stereotype.Component;
 
 import com.programmers.bucketback.domains.item.domain.Item;
 import com.programmers.bucketback.domains.item.repository.MemberItemRepository;
-import com.programmers.bucketback.error.exception.BusinessException;
-import com.programmers.bucketback.error.exception.ErrorCode;
+import com.programmers.bucketback.error.BusinessException;
+import com.programmers.bucketback.error.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
 

--- a/domain/src/main/java/com/programmers/bucketback/domains/member/domain/vo/Introduction.java
+++ b/domain/src/main/java/com/programmers/bucketback/domains/member/domain/vo/Introduction.java
@@ -1,7 +1,7 @@
 package com.programmers.bucketback.domains.member.domain.vo;
 
-import com.programmers.bucketback.error.exception.BusinessException;
-import com.programmers.bucketback.error.exception.ErrorCode;
+import com.programmers.bucketback.error.BusinessException;
+import com.programmers.bucketback.error.ErrorCode;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;

--- a/domain/src/main/java/com/programmers/bucketback/domains/member/domain/vo/LoginInfo.java
+++ b/domain/src/main/java/com/programmers/bucketback/domains/member/domain/vo/LoginInfo.java
@@ -3,8 +3,8 @@ package com.programmers.bucketback.domains.member.domain.vo;
 import java.util.Objects;
 import java.util.regex.Pattern;
 
-import com.programmers.bucketback.error.exception.BusinessException;
-import com.programmers.bucketback.error.exception.ErrorCode;
+import com.programmers.bucketback.error.BusinessException;
+import com.programmers.bucketback.error.ErrorCode;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;

--- a/domain/src/main/java/com/programmers/bucketback/domains/member/domain/vo/Nickname.java
+++ b/domain/src/main/java/com/programmers/bucketback/domains/member/domain/vo/Nickname.java
@@ -3,8 +3,8 @@ package com.programmers.bucketback.domains.member.domain.vo;
 import java.util.Objects;
 import java.util.regex.Pattern;
 
-import com.programmers.bucketback.error.exception.BusinessException;
-import com.programmers.bucketback.error.exception.ErrorCode;
+import com.programmers.bucketback.error.BusinessException;
+import com.programmers.bucketback.error.ErrorCode;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;

--- a/domain/src/main/java/com/programmers/bucketback/domains/member/implementation/MemberChecker.java
+++ b/domain/src/main/java/com/programmers/bucketback/domains/member/implementation/MemberChecker.java
@@ -3,8 +3,8 @@ package com.programmers.bucketback.domains.member.implementation;
 import org.springframework.stereotype.Component;
 
 import com.programmers.bucketback.domains.member.repository.MemberRepository;
-import com.programmers.bucketback.error.exception.BusinessException;
-import com.programmers.bucketback.error.exception.ErrorCode;
+import com.programmers.bucketback.error.BusinessException;
+import com.programmers.bucketback.error.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
 

--- a/domain/src/main/java/com/programmers/bucketback/domains/member/implementation/MemberReader.java
+++ b/domain/src/main/java/com/programmers/bucketback/domains/member/implementation/MemberReader.java
@@ -13,8 +13,8 @@ import com.programmers.bucketback.domains.member.domain.Member;
 import com.programmers.bucketback.domains.member.model.MemberProfile;
 import com.programmers.bucketback.domains.member.model.MyPage;
 import com.programmers.bucketback.domains.member.repository.MemberRepository;
-import com.programmers.bucketback.error.exception.EntityNotFoundException;
-import com.programmers.bucketback.error.exception.ErrorCode;
+import com.programmers.bucketback.error.EntityNotFoundException;
+import com.programmers.bucketback.error.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
 

--- a/domain/src/main/java/com/programmers/bucketback/domains/review/implementation/ReviewReader.java
+++ b/domain/src/main/java/com/programmers/bucketback/domains/review/implementation/ReviewReader.java
@@ -7,8 +7,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.programmers.bucketback.domains.review.domain.Review;
 import com.programmers.bucketback.domains.review.repository.ReviewRepository;
-import com.programmers.bucketback.error.exception.EntityNotFoundException;
-import com.programmers.bucketback.error.exception.ErrorCode;
+import com.programmers.bucketback.error.EntityNotFoundException;
+import com.programmers.bucketback.error.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
 

--- a/domain/src/main/java/com/programmers/bucketback/domains/vote/domain/vo/Content.java
+++ b/domain/src/main/java/com/programmers/bucketback/domains/vote/domain/vo/Content.java
@@ -2,8 +2,8 @@ package com.programmers.bucketback.domains.vote.domain.vo;
 
 import java.util.Objects;
 
-import com.programmers.bucketback.error.exception.BusinessException;
-import com.programmers.bucketback.error.exception.ErrorCode;
+import com.programmers.bucketback.error.BusinessException;
+import com.programmers.bucketback.error.ErrorCode;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;

--- a/domain/src/main/java/com/programmers/bucketback/domains/vote/implementation/VoteReader.java
+++ b/domain/src/main/java/com/programmers/bucketback/domains/vote/implementation/VoteReader.java
@@ -21,9 +21,9 @@ import com.programmers.bucketback.domains.vote.model.VoteSortCondition;
 import com.programmers.bucketback.domains.vote.model.VoteStatusCondition;
 import com.programmers.bucketback.domains.vote.model.VoteSummary;
 import com.programmers.bucketback.domains.vote.repository.VoteRepository;
-import com.programmers.bucketback.error.exception.BusinessException;
-import com.programmers.bucketback.error.exception.EntityNotFoundException;
-import com.programmers.bucketback.error.exception.ErrorCode;
+import com.programmers.bucketback.error.BusinessException;
+import com.programmers.bucketback.error.EntityNotFoundException;
+import com.programmers.bucketback.error.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
 

--- a/domain/src/main/java/com/programmers/bucketback/domains/vote/model/VoteSortCondition.java
+++ b/domain/src/main/java/com/programmers/bucketback/domains/vote/model/VoteSortCondition.java
@@ -6,8 +6,8 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import com.programmers.bucketback.error.exception.BusinessException;
-import com.programmers.bucketback.error.exception.ErrorCode;
+import com.programmers.bucketback.error.BusinessException;
+import com.programmers.bucketback.error.ErrorCode;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/domain/src/main/java/com/programmers/bucketback/domains/vote/model/VoteStatusCondition.java
+++ b/domain/src/main/java/com/programmers/bucketback/domains/vote/model/VoteStatusCondition.java
@@ -6,8 +6,8 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import com.programmers.bucketback.error.exception.BusinessException;
-import com.programmers.bucketback.error.exception.ErrorCode;
+import com.programmers.bucketback.error.BusinessException;
+import com.programmers.bucketback.error.ErrorCode;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/infrastructure/build.gradle
+++ b/infrastructure/build.gradle
@@ -1,12 +1,10 @@
 dependencies {
     // component를 대체할 의존성 붙여 두기
-    // mail
-    implementation 'org.springframework.boot:spring-boot-starter-mail'
-
-    implementation project(':common')
-    
     //crawling
     implementation 'org.jsoup:jsoup:1.16.2'
+
+    // mail
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 bootJar {

--- a/infrastructure/src/main/java/com/programmers/bucketback/crawling/CoupangCrawler.java
+++ b/infrastructure/src/main/java/com/programmers/bucketback/crawling/CoupangCrawler.java
@@ -2,9 +2,6 @@ package com.programmers.bucketback.crawling;
 
 import org.jsoup.nodes.Document;
 
-import com.programmers.bucketback.error.exception.BusinessException;
-import com.programmers.bucketback.error.exception.ErrorCode;
-
 public class CoupangCrawler implements WebCrawler {
 
 	private final String url;
@@ -37,7 +34,7 @@ public class CoupangCrawler implements WebCrawler {
 				.url(url)
 				.build();
 		} catch (Exception e) {
-			throw new BusinessException(ErrorCode.CRAWLER_COUPANG_BAD_REQUEST);
+			throw new RuntimeException("쿠팡 크롤러에서 파싱할 수 없는 URL 입니다.");
 		}
 	}
 }

--- a/infrastructure/src/main/java/com/programmers/bucketback/crawling/DanawaCrawler.java
+++ b/infrastructure/src/main/java/com/programmers/bucketback/crawling/DanawaCrawler.java
@@ -2,9 +2,6 @@ package com.programmers.bucketback.crawling;
 
 import org.jsoup.nodes.Document;
 
-import com.programmers.bucketback.error.exception.BusinessException;
-import com.programmers.bucketback.error.exception.ErrorCode;
-
 public class DanawaCrawler implements WebCrawler {
 
 	private final String url;
@@ -35,7 +32,7 @@ public class DanawaCrawler implements WebCrawler {
 				.url(url)
 				.build();
 		} catch (Exception e) {
-			throw new BusinessException(ErrorCode.CRAWLER_DANAWA_BAD_REQUEST);
+			throw new RuntimeException("다나와 크롤러에서 파싱할 수 없는 URL 입니다.");
 		}
 	}
 

--- a/infrastructure/src/main/java/com/programmers/bucketback/crawling/NaverCrawler.java
+++ b/infrastructure/src/main/java/com/programmers/bucketback/crawling/NaverCrawler.java
@@ -3,9 +3,6 @@ package com.programmers.bucketback.crawling;
 import org.jsoup.nodes.Document;
 import org.jsoup.select.Elements;
 
-import com.programmers.bucketback.error.exception.BusinessException;
-import com.programmers.bucketback.error.exception.ErrorCode;
-
 public class NaverCrawler implements WebCrawler {
 
 	private final String url;
@@ -21,7 +18,7 @@ public class NaverCrawler implements WebCrawler {
 
 			Elements elements = document.getElementsByClass("_22kNQuEXmb _copyable");
 			if (elements.size() == 0) {
-				throw new BusinessException(ErrorCode.INVALID_REQUEST);
+				throw new RuntimeException("유효하지 않은 요청입니다.");
 			}
 
 			String itemName = elements
@@ -42,7 +39,7 @@ public class NaverCrawler implements WebCrawler {
 				.url(url)
 				.build();
 		} catch (Exception e) {
-			throw new BusinessException(ErrorCode.CRAWLER_NAVER_BAD_REQUEST);
+			throw new RuntimeException("네이버 크롤러에서 파싱할 수 없는 URL 입니다.");
 		}
 
 	}

--- a/infrastructure/src/main/java/com/programmers/bucketback/crawling/WebSite.java
+++ b/infrastructure/src/main/java/com/programmers/bucketback/crawling/WebSite.java
@@ -2,9 +2,6 @@ package com.programmers.bucketback.crawling;
 
 import java.util.function.Function;
 
-import com.programmers.bucketback.error.exception.EntityNotFoundException;
-import com.programmers.bucketback.error.exception.ErrorCode;
-
 public enum WebSite {
 
 	NAVER("naver", NaverCrawler::new),
@@ -29,6 +26,6 @@ public enum WebSite {
 				return site.marketFactory.apply(url);
 			}
 		}
-		throw new EntityNotFoundException(ErrorCode.ITEM_MARKET_NOT_FOUND); // 정해진 웹사이트에 해당하는 정보가 아닌경우
+		throw new RuntimeException("지원하지 않는 아이템 URL 입니다."); // 정해진 웹사이트에 해당하는 정보가 아닌 경우
 	}
 }


### PR DESCRIPTION
## 📌 PR 종류

어떤 종류의 PR인지 아래 항목 중에 체크 해주세요.
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [ ]  🐛 버그 수정
- [ ]  ✨ 기능 추가
- [ ]  **✅** 테스트 추가
- [ ]  🎨 코드 스타일 변경 (formatting, local variables)
- [ ]  🔨 리팩토링 (기능 변경 X)
- [ ]  **💚** 빌드 관련 수정
- [ ]  **📝** 문서 내용 수정
- [ ]  그 외, 어떤 종류인지 기입 바람:
<br>

## 📌 어떤 기능이 추가 되었나요?

<!--어떤 기능이 추가 되었는지 설명해주시고 관련된 지라 이슈 넘버를 추가 해주세요 -->

### Issue Number

OMCT-247

### 기능 설명

-  infra 모듈에서 common 모듈 의존성 제거 0419ceea8274a7cd3084a7630a4263fe25a8698c
기존의 infra 모듈에 있는 클래스들에서 CustomException과 ErrorCode를 사용해서 common 모듈을 의존하고 있었습니다. RuntimeException으로 예외를 바꾸고 Infra 모듈에서 common 모듈 의존성을 제거하였습니다.

- 에러 메시지에 맞는 ErrorCode 반환 f850b8f8ef6f4c5e2b169c43c4512161f44c0f49
ErrorCode를 캐싱하여 메시지에 따라 ErrorCode 이넘을 반환하도록 변경하였습니다. infra 모듈에 있는 클래스들의 예외를 처리하기 위함입니다.

- GlobalExceptionHandler, ErrorResponse api 모듈로 이동 4b830cddc22e04f2ea11d736301c481416df5360
위의 두 클래스는 팀원들과 상의 후 api 모듈에 있는 것이 맞다고 판단하여 이동시켰습니다.

- MessagingException 핸들러 삭제 cf9197025da7e71567958f3e840b442fe978d15a
메일 예외도 RuntimeException으로 발생시키고 에러 메시지를 통해서 ErrorCode를 찾아서 처리합니다. 따라서 더 이상 사용되지 않는 MessagingException 핸들러를 삭제하였습니다.

- ErrorCode, Custom exception 상위 패키지로 이동 0bbe465641e23da939533347dc9399d5ac2f2d7e
GlobalExceptionHandler, ErrorResponse api 모듈로 이동하고 남은 에러 관련 클래스들을 상위 error 패키지로 이동 후 exception 패키지는 삭제하였습니다.

- 필요없는 의존성 제거 bca4ee1ca30ef2c366164770655c7969e4e651e3
리팩토링 후 필요 없어진 의존성들을 삭제하였습니다.

<br>

## 📌 기존에 있던 기능에 영향을 주나요?

- [ ]  네
- [x]  아니요

<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->
