### PR TITLE
[NO-JIRA] 커서 조회 시 빈 목록일 경우 예외 발생하는 버그 해결 + CursorUtils 클래스 리팩토링

### DIFF
--- a/bucketback-domain/src/main/java/com/programmers/bucketback/common/cursor/CursorUtils.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/common/cursor/CursorUtils.java
@@ -2,7 +2,11 @@ package com.programmers.bucketback.common.cursor;
 
 import java.util.List;
 
-public class CursorUtils {
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class CursorUtils {
 
 	public static <T extends CursorIdParser> CursorSummary<T> getCursorSummaries(final List<T> summaries) {
 		if (summaries.isEmpty()) {

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/common/cursor/CursorUtils.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/common/cursor/CursorUtils.java
@@ -5,11 +5,15 @@ import java.util.List;
 public class CursorUtils {
 
 	public static <T extends CursorIdParser> CursorSummary<T> getCursorSummaries(final List<T> summaries) {
-		T lastSummary = summaries.isEmpty() ? null : summaries.get(summaries.size() - 1);
+		if (summaries.isEmpty()) {
+			return new CursorSummary<>(null, 0, summaries);
+		}
+
+		T lastSummary = summaries.get(summaries.size() - 1);
 		String nextCursorId = lastSummary.cursorId();
 
 		int summaryCount = summaries.size();
 
-		return new CursorSummary<T>(nextCursorId, summaryCount, summaries);
+		return new CursorSummary<>(nextCursorId, summaryCount, summaries);
 	}
 }


### PR DESCRIPTION
## 📌 PR 종류

어떤 종류의 PR인지 아래 항목 중에 체크 해주세요.
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [x]  🐛 버그 수정
- [ ]  ✨ 기능 추가
- [ ]  **✅** 테스트 추가
- [ ]  🎨 코드 스타일 변경 (formatting, local variables)
- [ ]  🔨 리팩토링 (기능 변경 X)
- [ ]  **💚** 빌드 관련 수정
- [ ]  **📝** 문서 내용 수정
- [ ]  그 외, 어떤 종류인지 기입 바람:
<br>

## 📌 어떤 기능이 추가 되었나요?

<!--어떤 기능이 추가 되었는지 설명해주시고 관련된 지라 이슈 넘버를 추가 해주세요 -->

### Issue Number

NO-JIRA

### 기능 설명

- 빈 목록일 경우 lastSummary가 null 이기 때문에 cursorId가 없다는 예외가 발생했습니다.
- lastSummary 가 null이라면 cursorId도 null로 반환하도록 함으로써 버그를 해결했습니다.
- 추가로 CursorUtils 클래스를 유틸성 클래스로 만들기 위해서 final 클래스로 만들고 생성자를 private 하게 변경하였습니다.

<br>

## 📌 기존에 있던 기능에 영향을 주나요?

- [ ]  네
- [x]  아니요

<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->
