### PR TITLE
[OMCT-286] 리뷰생성할 때 아이템 아이디를 반환 하도록 기능 추가

### DIFF
--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/review/api/ReviewController.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/review/api/ReviewController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.programmers.bucketback.domains.review.api.dto.request.ReviewCreateRequest;
 import com.programmers.bucketback.domains.review.api.dto.request.ReviewUpdateRequest;
+import com.programmers.bucketback.domains.review.api.dto.response.ReviewCreateResponse;
 import com.programmers.bucketback.domains.review.api.dto.response.ReviewGetByCursorResponse;
 import com.programmers.bucketback.domains.review.application.ReviewService;
 import com.programmers.bucketback.domains.review.application.dto.ReviewGetByCursorServiceResponse;
@@ -33,13 +34,14 @@ public class ReviewController {
 
 	@Operation(summary = "아이템 리뷰 등록", description = "itemId, ReviewCreateRequest을 이용하여 아이템 리뷰를 등록 합니다.")
 	@PostMapping()
-	public ResponseEntity<Void> createReview(
+	public ResponseEntity<ReviewCreateResponse> createReview(
 		@PathVariable final Long itemId,
 		@Valid @RequestBody final ReviewCreateRequest request
 	) {
 		reviewService.createReview(itemId, request.toReviewContent());
+		ReviewCreateResponse response = new ReviewCreateResponse(itemId);
 
-		return ResponseEntity.ok().build();
+		return ResponseEntity.ok(response);
 	}
 
 	@Operation(summary = "아이템 리뷰 수정", description = "itemId, reviewId, ReviewUpdateRequest을 이용하여 아이템 리뷰를 수정 합니다.")

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/review/api/dto/response/ReviewCreateResponse.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/review/api/dto/response/ReviewCreateResponse.java
@@ -1,0 +1,6 @@
+package com.programmers.bucketback.domains.review.api.dto.response;
+
+public record ReviewCreateResponse(
+	Long itemId
+) {
+}


### PR DESCRIPTION
## 📌 PR 종류

어떤 종류의 PR인지 아래 항목 중에 체크 해주세요.
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [ ]  🐛 버그 수정
- [x]  ✨ 기능 추가
- [ ]  **✅** 테스트 추가
- [ ]  🎨 코드 스타일 변경 (formatting, local variables)
- [ ]  🔨 리팩토링 (기능 변경 X)
- [ ]  **💚** 빌드 관련 수정
- [ ]  **📝** 문서 내용 수정
- [ ]  그 외, 어떤 종류인지 기입 바람:
<br>

## 📌 어떤 기능이 추가 되었나요?

리뷰생성할 때 아이템 아이디를 반환 하도록 기능 추가

### Issue Number

OMCT-286

### 기능 설명

리뷰생성할 때 아이템 아이디를 반환 하도록 기능 추가
- 리뷰한 아이템의 아이디를 반환 합니다.
- 
## 📌 기존에 있던 기능에 영향을 주나요?

- [ ]  네
- [x]  아니요

<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->
