### PR TITLE
[NO-JIRA] 투표 상세 조회 관련 버그 수정

### DIFF
--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/vote/api/dto/request/VoteCreateRequest.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/vote/api/dto/request/VoteCreateRequest.java
@@ -10,7 +10,7 @@ import jakarta.validation.constraints.Size;
 public record VoteCreateRequest(
 	@Schema(description = "취미", example = "농구")
 	@NotNull(message = "취미는 필수 값입니다.")
-	String hobbyValue,
+	String hobby,
 
 	@Schema(description = "투표 내용", example = "어떤 농구화가 더 이쁜가?")
 	@Size(max = 1000, message = "투표 내용은 최대 1000자 입니다.")
@@ -26,10 +26,8 @@ public record VoteCreateRequest(
 	Long item2Id
 ) {
 	public VoteCreateServiceRequest toCreateVoteServiceRequest() {
-		Hobby hobby = Hobby.fromHobbyValue(hobbyValue);
-
 		return VoteCreateServiceRequest.builder()
-			.hobby(hobby)
+			.hobby(Hobby.fromHobbyValue(hobby))
 			.content(content)
 			.item1Id(item1Id)
 			.item2Id(item2Id)

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/vote/api/dto/response/VoteGetResponse.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/vote/api/dto/response/VoteGetResponse.java
@@ -3,7 +3,7 @@ package com.programmers.bucketback.domains.vote.api.dto.response;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.programmers.bucketback.domains.item.model.ItemInfo;
 import com.programmers.bucketback.domains.vote.application.dto.response.VoteGetServiceResponse;
-import com.programmers.bucketback.domains.vote.model.VoteInfo;
+import com.programmers.bucketback.domains.vote.model.VoteDetailInfo;
 
 import lombok.Builder;
 
@@ -11,7 +11,7 @@ import lombok.Builder;
 public record VoteGetResponse(
 	ItemInfo item1Info,
 	ItemInfo item2Info,
-	VoteInfo voteInfo,
+	VoteDetailInfo voteInfo,
 	boolean isOwner,
 
 	@JsonInclude(JsonInclude.Include.NON_NULL)

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/vote/application/VoteService.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/vote/application/VoteService.java
@@ -12,6 +12,7 @@ import com.programmers.bucketback.domains.vote.implementation.VoteAppender;
 import com.programmers.bucketback.domains.vote.implementation.VoteManager;
 import com.programmers.bucketback.domains.vote.implementation.VoteReader;
 import com.programmers.bucketback.domains.vote.implementation.VoteRemover;
+import com.programmers.bucketback.domains.vote.model.VoteDetail;
 import com.programmers.bucketback.domains.vote.model.VoteSortCondition;
 import com.programmers.bucketback.domains.vote.model.VoteStatusCondition;
 import com.programmers.bucketback.domains.vote.model.VoteSummary;
@@ -74,9 +75,9 @@ public class VoteService {
 
 	public VoteGetServiceResponse getVote(final Long voteId) {
 		final Long memberId = MemberUtils.getCurrentMemberId();
-		final VoteSummary summary = voteReader.read(voteId, memberId);
+		final VoteDetail detail = voteReader.read(voteId, memberId);
 
-		return VoteGetServiceResponse.from(summary);
+		return VoteGetServiceResponse.from(detail);
 	}
 
 	public CursorSummary<VoteSummary> getVotesByCursor(

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/vote/application/dto/response/VoteGetServiceResponse.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/vote/application/dto/response/VoteGetServiceResponse.java
@@ -20,7 +20,7 @@ public record VoteGetServiceResponse(
 			.item2Info(summary.item2Info())
 			.voteInfo(summary.voteInfo())
 			.isOwner(summary.isOwner())
-			.selectedItemId(builder().selectedItemId)
+			.selectedItemId(summary.selectedItemId())
 			.build();
 	}
 }

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/vote/application/dto/response/VoteGetServiceResponse.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/vote/application/dto/response/VoteGetServiceResponse.java
@@ -1,8 +1,8 @@
 package com.programmers.bucketback.domains.vote.application.dto.response;
 
 import com.programmers.bucketback.domains.item.model.ItemInfo;
-import com.programmers.bucketback.domains.vote.model.VoteInfo;
-import com.programmers.bucketback.domains.vote.model.VoteSummary;
+import com.programmers.bucketback.domains.vote.model.VoteDetail;
+import com.programmers.bucketback.domains.vote.model.VoteDetailInfo;
 
 import lombok.Builder;
 
@@ -10,17 +10,17 @@ import lombok.Builder;
 public record VoteGetServiceResponse(
 	ItemInfo item1Info,
 	ItemInfo item2Info,
-	VoteInfo voteInfo,
+	VoteDetailInfo voteInfo,
 	boolean isOwner,
 	Long selectedItemId
 ) {
-	public static VoteGetServiceResponse from(final VoteSummary summary) {
+	public static VoteGetServiceResponse from(final VoteDetail detail) {
 		return VoteGetServiceResponse.builder()
-			.item1Info(summary.item1Info())
-			.item2Info(summary.item2Info())
-			.voteInfo(summary.voteInfo())
-			.isOwner(summary.isOwner())
-			.selectedItemId(summary.selectedItemId())
+			.item1Info(detail.item1Info())
+			.item2Info(detail.item2Info())
+			.voteInfo(detail.voteInfo())
+			.isOwner(detail.isOwner())
+			.selectedItemId(detail.selectedItemId())
 			.build();
 	}
 }

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/domains/vote/implementation/VoteReader.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/domains/vote/implementation/VoteReader.java
@@ -89,7 +89,7 @@ public class VoteReader {
 			pageSize
 		);
 
-		final List<VoteSummary> voteSummaries = getVoteCursorSummaries(voteCursorSummaries);
+		final List<VoteSummary> voteSummaries = getVoteSummaries(voteCursorSummaries);
 
 		return CursorUtils.getCursorSummaries(voteSummaries);
 	}
@@ -114,7 +114,7 @@ public class VoteReader {
 			.orElse(null);
 	}
 
-	private List<VoteSummary> getVoteCursorSummaries(final List<VoteCursorSummary> voteSummaries) {
+	private List<VoteSummary> getVoteSummaries(final List<VoteCursorSummary> voteSummaries) {
 		return voteSummaries.stream()
 			.map(voteCursorSummary -> {
 				final Long item1Id = voteCursorSummary.item1Id();

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/domains/vote/implementation/VoteReader.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/domains/vote/implementation/VoteReader.java
@@ -16,7 +16,8 @@ import com.programmers.bucketback.domains.item.model.ItemInfo;
 import com.programmers.bucketback.domains.vote.domain.Vote;
 import com.programmers.bucketback.domains.vote.domain.Voter;
 import com.programmers.bucketback.domains.vote.model.VoteCursorSummary;
-import com.programmers.bucketback.domains.vote.model.VoteInfo;
+import com.programmers.bucketback.domains.vote.model.VoteDetail;
+import com.programmers.bucketback.domains.vote.model.VoteDetailInfo;
 import com.programmers.bucketback.domains.vote.model.VoteSortCondition;
 import com.programmers.bucketback.domains.vote.model.VoteStatusCondition;
 import com.programmers.bucketback.domains.vote.model.VoteSummary;
@@ -44,7 +45,7 @@ public class VoteReader {
 	}
 
 	@Transactional(readOnly = true)
-	public VoteSummary read(
+	public VoteDetail read(
 		final Long voteId,
 		final Long memberId
 	) {
@@ -56,12 +57,12 @@ public class VoteReader {
 
 		final int item1Votes = voteCounter.count(vote, item1Id);
 		final int item2Votes = voteCounter.count(vote, item2Id);
-		final VoteInfo voteInfo = VoteInfo.of(vote, item1Votes, item2Votes);
+		final VoteDetailInfo voteInfo = VoteDetailInfo.of(vote, item1Votes, item2Votes);
 
 		final boolean isOwner = vote.isOwner(memberId);
 		final Long selectedItemId = getSelectedItemId(vote, memberId);
 
-		return VoteSummary.builder()
+		return VoteDetail.builder()
 			.item1Info(item1Info)
 			.item2Info(item2Info)
 			.voteInfo(voteInfo)

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/domains/vote/model/VoteDetail.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/domains/vote/model/VoteDetail.java
@@ -1,0 +1,15 @@
+package com.programmers.bucketback.domains.vote.model;
+
+import com.programmers.bucketback.domains.item.model.ItemInfo;
+
+import lombok.Builder;
+
+@Builder
+public record VoteDetail(
+	VoteDetailInfo voteInfo,
+	ItemInfo item1Info,
+	ItemInfo item2Info,
+	boolean isOwner,
+	Long selectedItemId
+	) {
+}

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/domains/vote/model/VoteDetailInfo.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/domains/vote/model/VoteDetailInfo.java
@@ -1,0 +1,34 @@
+package com.programmers.bucketback.domains.vote.model;
+
+import java.time.LocalDateTime;
+
+import com.programmers.bucketback.domains.vote.domain.Vote;
+
+import lombok.Builder;
+
+@Builder
+public record VoteDetailInfo(
+	Long id,
+	String content,
+	LocalDateTime startTime,
+	boolean isVoting,
+	int participants,
+	int item1Votes,
+	int item2Votes
+) {
+	public static VoteDetailInfo of(
+		final Vote vote,
+		final int item1Votes,
+		final int item2Votes
+	) {
+		return VoteDetailInfo.builder()
+			.id(vote.getId())
+			.content(vote.getContent())
+			.startTime(vote.getStartTime())
+			.isVoting(vote.isVoting())
+			.participants(item1Votes + item2Votes)
+			.item1Votes(item1Votes)
+			.item2Votes(item2Votes)
+			.build();
+	}
+}

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/domains/vote/model/VoteInfo.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/domains/vote/model/VoteInfo.java
@@ -39,7 +39,7 @@ public record VoteInfo(
 			.id(vote.getId())
 			.content(vote.getContent())
 			.startTime(vote.getStartTime())
-			.isVoting(isVoting(vote.getEndTime()))
+			.isVoting(vote.isVoting())
 			.participants(item1Votes + item2Votes)
 			.item1Votes(item1Votes)
 			.item2Votes(item2Votes)
@@ -48,6 +48,6 @@ public record VoteInfo(
 
 	private static boolean isVoting(final LocalDateTime endTime) {
 		return LocalDateTime.now()
-			.isAfter(endTime);
+			.isBefore(endTime);
 	}
 }

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/domains/vote/model/VoteInfo.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/domains/vote/model/VoteInfo.java
@@ -13,11 +13,7 @@ public record VoteInfo(
 	LocalDateTime startTime,
 	boolean isVoting,
 	int participants,
-
-	// @JsonInclude(JsonInclude.Include.NON_NULL)
 	Integer item1Votes,
-
-	// @JsonInclude(JsonInclude.Include.NON_NULL)
 	Integer item2Votes
 ) {
 	public VoteInfo(

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/domains/vote/model/VoteInfo.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/domains/vote/model/VoteInfo.java
@@ -2,8 +2,6 @@ package com.programmers.bucketback.domains.vote.model;
 
 import java.time.LocalDateTime;
 
-import com.programmers.bucketback.domains.vote.domain.Vote;
-
 import lombok.Builder;
 
 @Builder
@@ -12,9 +10,7 @@ public record VoteInfo(
 	String content,
 	LocalDateTime startTime,
 	boolean isVoting,
-	int participants,
-	Integer item1Votes,
-	Integer item2Votes
+	int participants
 ) {
 	public VoteInfo(
 		final Long id,
@@ -23,23 +19,7 @@ public record VoteInfo(
 		final LocalDateTime endTime,
 		final int participants
 	) {
-		this(id, content, startTime, isVoting(endTime), participants, null, null);
-	}
-
-	public static VoteInfo of(
-		final Vote vote,
-		final int item1Votes,
-		final int item2Votes
-	) {
-		return VoteInfo.builder()
-			.id(vote.getId())
-			.content(vote.getContent())
-			.startTime(vote.getStartTime())
-			.isVoting(vote.isVoting())
-			.participants(item1Votes + item2Votes)
-			.item1Votes(item1Votes)
-			.item2Votes(item2Votes)
-			.build();
+		this(id, content, startTime, isVoting(endTime), participants);
 	}
 
 	private static boolean isVoting(final LocalDateTime endTime) {

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/domains/vote/model/VoteSummary.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/domains/vote/model/VoteSummary.java
@@ -11,7 +11,7 @@ public record VoteSummary(
 	VoteInfo voteInfo,
 	ItemInfo item1Info,
 	ItemInfo item2Info,
-	boolean isOwner,
+	Boolean isOwner,
 	Long selectedItemId,
 	String cursorId
 ) implements CursorIdParser {

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/domains/vote/model/VoteSummary.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/domains/vote/model/VoteSummary.java
@@ -11,8 +11,6 @@ public record VoteSummary(
 	VoteInfo voteInfo,
 	ItemInfo item1Info,
 	ItemInfo item2Info,
-	Boolean isOwner,
-	Long selectedItemId,
 	String cursorId
 ) implements CursorIdParser {
 	public static VoteSummary of(


### PR DESCRIPTION
## 📌 PR 종류

어떤 종류의 PR인지 아래 항목 중에 체크 해주세요.
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [x]  🐛 버그 수정
- [ ]  ✨ 기능 추가
- [ ]  **✅** 테스트 추가
- [ ]  🎨 코드 스타일 변경 (formatting, local variables)
- [ ]  🔨 리팩토링 (기능 변경 X)
- [ ]  **💚** 빌드 관련 수정
- [ ]  **📝** 문서 내용 수정
- [ ]  그 외, 어떤 종류인지 기입 바람:
<br>

## 📌 어떤 기능이 추가 되었나요?

<!--어떤 기능이 추가 되었는지 설명해주시고 관련된 지라 이슈 넘버를 추가 해주세요 -->

### Issue Number

NO-JIRA

### 해결한 버그 설명

- 종료된 투표와 진행 중인 투표 상태가 반대로 나오는 버그 수정 9530aa12d8eac6c4dbd5c9eba73a85e5d6d0b070
- 투표에서 선택한 아이템 id 안보이는 버그 수정 19372b0e9ebf09ae247b222794fa244fba14fd11

### @JsonInclude(JsonInclude.Include.NON_NULL) 대신 yml에 설정 추가
- 멀티모듈로 전환하는 과정에서 model 클래스들은 domain 모듈에 있기 때문에 `@JsonInclude(JsonInclude.Include.NON_NULL)`을 사용할 수 없게 되었습니다. 어노테이션 말고 yml에 아래 설정을 추가하여 이 문제를 해결할 수 있습니다.
```
  jackson:
    default-property-inclusion: non_null
```

<br>

## 📌 기존에 있던 기능에 영향을 주나요?

- [ ]  네
- [x]  아니요

<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->
