### PR TITLE
[OMCT-289] 나의 아이템 목록 조회에 취미 파라미터 추가

### DIFF
--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/item/api/ItemController.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/item/api/ItemController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.programmers.bucketback.common.cursor.CursorSummary;
+import com.programmers.bucketback.common.model.Hobby;
 import com.programmers.bucketback.domains.item.api.dto.request.ItemEnrollRequest;
 import com.programmers.bucketback.domains.item.api.dto.request.MemberItemAddRequest;
 import com.programmers.bucketback.domains.item.api.dto.response.ItemAddResponse;
@@ -106,9 +107,16 @@ public class ItemController {
 	@Operation(summary = "나의 아이템 목록 조회", description = "나의 아이템 목록을 조회 합니다.")
 	@GetMapping("/myitems")
 	public ResponseEntity<MemberItemGetByCursorResponse> getMemberItemsByCursor(
+		@RequestParam(required = false) final String hobbyName,
 		@ModelAttribute("request") @Valid final CursorRequest request
 	) {
+		Hobby hobby = null;
+		if (hobbyName != null) {
+			hobby = Hobby.fromName(hobbyName);
+		}
+
 		CursorSummary<MemberItemSummary> cursorSummary = itemService.getMemberItemsByCursor(
+			hobby,
 			request.toParameters()
 		);
 		MemberItemGetByCursorResponse response = MemberItemGetByCursorResponse.from(cursorSummary);

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/item/api/ItemController.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/item/api/ItemController.java
@@ -110,11 +110,7 @@ public class ItemController {
 		@RequestParam(required = false) final String hobbyName,
 		@ModelAttribute("request") @Valid final CursorRequest request
 	) {
-		Hobby hobby = null;
-		if (hobbyName != null) {
-			hobby = Hobby.fromName(hobbyName);
-		}
-
+		Hobby hobby = Hobby.fromName(hobbyName);
 		CursorSummary<MemberItemSummary> cursorSummary = itemService.getMemberItemsByCursor(
 			hobby,
 			request.toParameters()

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/item/application/ItemService.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/item/application/ItemService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 
 import com.programmers.bucketback.common.cursor.CursorPageParameters;
 import com.programmers.bucketback.common.cursor.CursorSummary;
+import com.programmers.bucketback.common.model.Hobby;
 import com.programmers.bucketback.common.model.ItemIdRegistry;
 import com.programmers.bucketback.domains.item.application.dto.ItemAddServiceResponse;
 import com.programmers.bucketback.domains.item.application.dto.ItemGetNamesServiceResponse;
@@ -87,10 +88,14 @@ public class ItemService {
 		);
 	}
 
-	public CursorSummary<MemberItemSummary> getMemberItemsByCursor(final CursorPageParameters parameters) {
+	public CursorSummary<MemberItemSummary> getMemberItemsByCursor(
+		final Hobby hobby,
+		final CursorPageParameters parameters
+	) {
 		Long memberId = MemberUtils.getCurrentMemberId();
 
 		return memberItemReader.readMemberItem(
+			hobby,
 			memberId,
 			parameters
 		);

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/common/model/Hobby.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/common/model/Hobby.java
@@ -2,6 +2,7 @@ package com.programmers.bucketback.common.model;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -39,6 +40,11 @@ public enum Hobby {
 	private final String name;
 
 	public static Hobby fromName(final String name) {
+
+		if (Objects.isNull(name)) {
+			return null;
+		}
+
 		String nameLowerCase = name.toLowerCase();
 		if (HOBBY_NAME_MAP.containsKey(nameLowerCase)) {
 			return HOBBY_NAME_MAP.get(nameLowerCase);

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/domains/item/implementation/MemberItemReader.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/domains/item/implementation/MemberItemReader.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.programmers.bucketback.common.cursor.CursorPageParameters;
 import com.programmers.bucketback.common.cursor.CursorSummary;
 import com.programmers.bucketback.common.cursor.CursorUtils;
+import com.programmers.bucketback.common.model.Hobby;
 import com.programmers.bucketback.domains.bucket.model.BucketMemberItemSummary;
 import com.programmers.bucketback.domains.item.domain.Item;
 import com.programmers.bucketback.domains.item.domain.MemberItem;
@@ -63,11 +64,13 @@ public class MemberItemReader {
 	}
 
 	public CursorSummary<MemberItemSummary> readMemberItem(
+		final Hobby hobby,
 		final Long memberId,
 		final CursorPageParameters parameters
 	) {
 		int size = getPageSize(parameters);
 		List<MemberItemSummary> memberItemsByCursor = memberItemRepository.findMemberItemsByCursor(
+			hobby,
 			memberId,
 			parameters.cursorId(),
 			size

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/domains/item/repository/MemberItemRepositoryForCursor.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/domains/item/repository/MemberItemRepositoryForCursor.java
@@ -2,6 +2,7 @@ package com.programmers.bucketback.domains.item.repository;
 
 import java.util.List;
 
+import com.programmers.bucketback.common.model.Hobby;
 import com.programmers.bucketback.domains.bucket.model.BucketMemberItemSummary;
 import com.programmers.bucketback.domains.item.model.MemberItemSummary;
 
@@ -15,6 +16,7 @@ public interface MemberItemRepositoryForCursor {
 	);
 
 	List<MemberItemSummary> findMemberItemsByCursor(
+		final Hobby hobby,
 		final Long memberId,
 		final String cursorId,
 		final int pageSize

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/domains/item/repository/MemberItemRepositoryForCursorImpl.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/domains/item/repository/MemberItemRepositoryForCursorImpl.java
@@ -6,6 +6,7 @@ import static com.querydsl.core.group.GroupBy.*;
 
 import java.util.List;
 
+import com.programmers.bucketback.common.model.Hobby;
 import com.programmers.bucketback.domains.bucket.model.BucketMemberItemSummary;
 import com.programmers.bucketback.domains.item.model.ItemInfo;
 import com.programmers.bucketback.domains.item.model.MemberItemSummary;
@@ -61,6 +62,7 @@ public class MemberItemRepositoryForCursorImpl implements MemberItemRepositoryFo
 
 	@Override
 	public List<MemberItemSummary> findMemberItemsByCursor(
+		final Hobby hobby,
 		final Long memberId,
 		final String cursorId,
 		final int pageSize
@@ -86,6 +88,7 @@ public class MemberItemRepositoryForCursorImpl implements MemberItemRepositoryFo
 			).from(item)
 			.where(
 				cursorIdConditionFromMemberItem(cursorId),
+				hobbyCondition(hobby),
 				item.id.in(itemIdsFromMemberItem)
 			).orderBy(new OrderSpecifier<>(Order.DESC, item.createdAt))
 			.limit(pageSize)
@@ -97,6 +100,14 @@ public class MemberItemRepositoryForCursorImpl implements MemberItemRepositoryFo
 			.when(memberItem.item.id.in(itemIdsFromBucketItem))
 			.then(true)
 			.otherwise(false);
+	}
+
+	private BooleanExpression hobbyCondition(final Hobby hobby) {
+		if (hobby == null) {
+			return null;
+		}
+
+		return item.hobby.eq(hobby);
 	}
 
 	private BooleanExpression cursorIdConditionFromMemberItem(final String cursorId) {


### PR DESCRIPTION
## 📌 PR 종류

어떤 종류의 PR인지 아래 항목 중에 체크 해주세요.
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [ ]  🐛 버그 수정
- [x]  ✨ 기능 추가
- [ ]  **✅** 테스트 추가
- [ ]  🎨 코드 스타일 변경 (formatting, local variables)
- [ ]  🔨 리팩토링 (기능 변경 X)
- [ ]  **💚** 빌드 관련 수정
- [ ]  **📝** 문서 내용 수정
- [ ]  그 외, 어떤 종류인지 기입 바람:
<br>

## 📌 어떤 기능이 추가 되었나요?

나의 아이템 목록 조회에 취미 파라미터 추가

<!--어떤 기능이 추가 되었는지 설명해주시고 관련된 지라 이슈 넘버를 추가 해주세요 -->

### Issue Number

[OMCT-289]

### 기능 설명

나의 아이템 목록 조회에 취미 파라미터 추가
- 취미를 입력하면 나의 아이템 목록 조회중 입력한 취미와 일치하는 아이템을 반환 합니다.

## 📌 기존에 있던 기능에 영향을 주나요?

- [ ]  네
- [x]  아니요

<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->


[OMCT-289]: https://ohmycourse.atlassian.net/browse/OMCT-289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ