### PR TITLE
[NO-JIRA] 회원 프로필 이미지 관련 기능 추가 (프로필 이미지 삭제, 피드 목록 조회 시 프로필 이미지 반환)

### DIFF
--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/member/api/MemberController.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/member/api/MemberController.java
@@ -128,7 +128,9 @@ public class MemberController {
 
 	@PutMapping("/profile/image")
 	@ResponseBody
-	public ResponseEntity<Void> upload(@RequestParam("image") final MultipartFile multipartFile) throws IOException {
+	public ResponseEntity<Void> upload(
+		@RequestParam(name = "image", required = false) final MultipartFile multipartFile
+	) throws IOException {
 		memberService.updateProfileImage(multipartFile);
 
 		return ResponseEntity.ok().build();

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/member/api/MemberController.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/member/api/MemberController.java
@@ -129,7 +129,7 @@ public class MemberController {
 	@PutMapping("/profile/image")
 	@ResponseBody
 	public ResponseEntity<Void> upload(@RequestParam("image") final MultipartFile multipartFile) throws IOException {
-		memberService.updateProfileImage(multipartFile, "bucketback-static");
+		memberService.updateProfileImage(multipartFile);
 
 		return ResponseEntity.ok().build();
 	}

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/member/application/MemberService.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/member/application/MemberService.java
@@ -28,6 +28,7 @@ import lombok.RequiredArgsConstructor;
 public class MemberService {
 
 	public static final String DIRECTORY = "bucketback-static";
+	public static final String BASE_EXTENSION = ".png";
 
 	private final MemberAppender memberAppender;
 	private final MemberReader memberReader;
@@ -103,10 +104,10 @@ public class MemberService {
 
 	public void updateProfileImage(final MultipartFile multipartFile) throws IOException {
 		final Long memberId = MemberUtils.getCurrentMemberId();
-		final String profileImage = memberId + ".png";
+		final String profileImage = memberId + BASE_EXTENSION;
 
 		s3Manager.deleteFile(profileImage, DIRECTORY);
 		s3Manager.uploadFile(multipartFile, DIRECTORY, profileImage);
-		memberModifier.modifyProfileImage(memberId, profileImage);
+		memberModifier.modifyProfileImage(memberId, DIRECTORY, profileImage);
 	}
 }

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/member/application/MemberService.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/member/application/MemberService.java
@@ -27,6 +27,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class MemberService {
 
+	public static final String DIRECTORY = "bucketback-static";
+
 	private final MemberAppender memberAppender;
 	private final MemberReader memberReader;
 	private final MemberRemover memberRemover;
@@ -99,15 +101,12 @@ public class MemberService {
 		return memberReader.readMyPage(nickname);
 	}
 
-	public void updateProfileImage(
-		final MultipartFile multipartFile,
-		final String directory
-	) throws IOException {
+	public void updateProfileImage(final MultipartFile multipartFile) throws IOException {
 		final Long memberId = MemberUtils.getCurrentMemberId();
 		final String profileImage = memberId + ".png";
 
-		s3Manager.deleteFile(profileImage, directory);
-		s3Manager.uploadFile(multipartFile, directory, profileImage);
+		s3Manager.deleteFile(profileImage, DIRECTORY);
+		s3Manager.uploadFile(multipartFile, DIRECTORY, profileImage);
 		memberModifier.modifyProfileImage(memberId, profileImage);
 	}
 }

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/member/application/MemberService.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/member/application/MemberService.java
@@ -107,6 +107,12 @@ public class MemberService {
 		final String profileImage = memberId + BASE_EXTENSION;
 
 		s3Manager.deleteFile(profileImage, DIRECTORY);
+
+		if (multipartFile == null) {
+			memberRemover.removeProfileImage(memberId);
+			return;
+		}
+
 		s3Manager.uploadFile(multipartFile, DIRECTORY, profileImage);
 		memberModifier.modifyProfileImage(memberId, DIRECTORY, profileImage);
 	}

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/domains/feed/repository/FeedRepositoryForCursorImpl.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/domains/feed/repository/FeedRepositoryForCursorImpl.java
@@ -64,6 +64,7 @@ public class FeedRepositoryForCursorImpl implements FeedRepositoryForCursor {
 								MemberInfo.class,
 								member.id,
 								member.nickname.nickname,
+								member.profileImage,
 								member.levelPoint
 							),
 							feedItem.feed.id,

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/domains/member/implementation/MemberModifier.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/domains/member/implementation/MemberModifier.java
@@ -11,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class MemberModifier {
 
+	public static final String IMAGE_BASE_PATH = "https://team-02-bucket.s3.ap-northeast-2.amazonaws.com/";
+
 	private final MemberReader memberReader;
 	private final MemberChecker memberChecker;
 
@@ -41,9 +43,12 @@ public class MemberModifier {
 	@Transactional
 	public void modifyProfileImage(
 		final Long memberId,
+		final String directory,
 		final String profileImage
 	) {
 		final Member member = memberReader.read(memberId);
-		member.updateProfileImage(profileImage);
+		final String imagePath = IMAGE_BASE_PATH + directory + "/" + profileImage;
+
+		member.updateProfileImage(imagePath);
 	}
 }

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/domains/member/implementation/MemberRemover.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/domains/member/implementation/MemberRemover.java
@@ -18,4 +18,10 @@ public class MemberRemover {
 		final Member member = memberReader.read(memberId);
 		member.delete();
 	}
+
+	@Transactional
+	public void removeProfileImage(final Long memberId) {
+		final Member member = memberReader.read(memberId);
+		member.updateProfileImage(null);
+	}
 }

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/domains/member/model/MemberInfo.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/domains/member/model/MemberInfo.java
@@ -15,12 +15,21 @@ public record MemberInfo(
 	public MemberInfo(
 		final Long memberId,
 		final String nickName,
-		final int levelPoint
+		final String profileImage,
+		final int level
 	) {
-		this(memberId, nickName, null, Level.from(levelPoint));
+		this.memberId = memberId;
+		this.nickName = nickName;
+		this.profileImage = profileImage;
+		this.level =  Level.from(level);
 	}
 
 	public static MemberInfo from(final Member member) {
-		return new MemberInfo(member.getId(), member.getNickname(), member.getLevel());
+		return MemberInfo.builder()
+			.memberId(member.getId())
+			.nickName(member.getNickname())
+			.profileImage(member.getProfileImage())
+			.level(member.getLevel())
+			.build();
 	}
 }

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/domains/member/model/MemberInfo.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/domains/member/model/MemberInfo.java
@@ -3,9 +3,6 @@ package com.programmers.bucketback.domains.member.model;
 import com.programmers.bucketback.domains.member.domain.Level;
 import com.programmers.bucketback.domains.member.domain.Member;
 
-import lombok.Builder;
-
-@Builder
 public record MemberInfo(
 	Long memberId,
 	String nickName,
@@ -25,11 +22,11 @@ public record MemberInfo(
 	}
 
 	public static MemberInfo from(final Member member) {
-		return MemberInfo.builder()
-			.memberId(member.getId())
-			.nickName(member.getNickname())
-			.profileImage(member.getProfileImage())
-			.level(member.getLevel())
-			.build();
+		return new MemberInfo(
+			member.getId(),
+			member.getNickname(),
+			member.getProfileImage(),
+			member.getLevel()
+		);
 	}
 }


### PR DESCRIPTION
## 📌 PR 종류

어떤 종류의 PR인지 아래 항목 중에 체크 해주세요.
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [ ]  🐛 버그 수정
- [x]  ✨ 기능 추가
- [ ]  **✅** 테스트 추가
- [ ]  🎨 코드 스타일 변경 (formatting, local variables)
- [ ]  🔨 리팩토링 (기능 변경 X)
- [ ]  **💚** 빌드 관련 수정
- [ ]  **📝** 문서 내용 수정
- [ ]  그 외, 어떤 종류인지 기입 바람:
<br>

## 📌 어떤 기능이 추가 되었나요?

<!--어떤 기능이 추가 되었는지 설명해주시고 관련된 지라 이슈 넘버를 추가 해주세요 -->

### Issue Number

NO-JIRA

### 기능 설명

- Member 엔티티에 프로필 이미지 전체 경로 저장 [7258a9b](https://github.com/bucket-back/bucket-back-backend/pull/145/commits/7258a9bc3e429692425796bebb051448953e4059)
- 프로필 이미지 수정 시 파일이 안올 경우 프로필 이미지 삭제 기능 추가 [aa5ee3a](https://github.com/bucket-back/bucket-back-backend/pull/145/commits/aa5ee3a7f24b1812c46dbddb909eee9f45c9186b)
- 피드 목록 조회 시 프로필 이미지도 같이 반환 [7ba81e9](https://github.com/bucket-back/bucket-back-backend/pull/145/commits/7ba81e97f4f197b7610cbbb430e791c74301dd21)

<br>

## 📌 기존에 있던 기능에 영향을 주나요?

- [x]  네
- [ ]  아니요

<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->
- 프로필 이미지도 추가 반환
