### PR TITLE
[OMCT-288] bucket-inventory 생성 및 수정시 조회하는  api 통일

### DIFF
--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/bucket/api/BucketController.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/bucket/api/BucketController.java
@@ -55,15 +55,17 @@ public class BucketController {
 	}
 
 	@Operation(summary = "버킷 수정을 위한 내가 담은 아이템 목록 커서 조회")
-	@GetMapping("/buckets/{bucketId}/myitems")
+	@GetMapping("/buckets/myitems")
 	public ResponseEntity<BucketGetMemberItemResponse> getMemberItemsForModify(
-		@PathVariable final Long bucketId,
+		@RequestParam(required = false) final Long bucketId,
+		@RequestParam(required = false) final String hobbyName,
 		@ModelAttribute @Valid final CursorRequest cursorRequest
 	) {
 
 		BucketGetMemberItemResponse response = BucketGetMemberItemResponse.from(
 			bucketService.getMemberItemsForModify(
 				bucketId,
+				Hobby.fromName(hobbyName),
 				cursorRequest.toParameters()
 			)
 		);

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/bucket/api/BucketController.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/bucket/api/BucketController.java
@@ -54,7 +54,7 @@ public class BucketController {
 		return ResponseEntity.ok().build();
 	}
 
-	@Operation(summary = "버킷 수정을 위한 내가 담은 아이템 목록 커서 조회")
+	@Operation(summary = "버킷 조회 수정을 위한 내가 담은 아이템 목록 커서 조회")
 	@GetMapping("/buckets/myitems")
 	public ResponseEntity<BucketGetMemberItemResponse> getMemberItemsForModify(
 		@RequestParam(required = false) final Long bucketId,

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/bucket/application/BucketService.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/bucket/application/BucketService.java
@@ -69,11 +69,17 @@ public class BucketService {
 	 */
 	public CursorSummary<BucketMemberItemSummary> getMemberItemsForModify(
 		final Long bucketId,
+		final Hobby hobby,
 		final CursorPageParameters parameters
 	) {
 		Long memberId = MemberUtils.getCurrentMemberId();
 
-		return bucketReader.readByMemberItems(bucketId, memberId, parameters);
+		return bucketReader.readByMemberItems(
+			bucketId,
+			memberId,
+			hobby,
+			parameters
+		);
 	}
 
 	/**

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/bucket/application/BucketService.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/bucket/application/BucketService.java
@@ -65,7 +65,7 @@ public class BucketService {
 	}
 
 	/**
-	 * 버킷 수정을 위한 멤버 아이템 목록 조회
+	 * 버킷 조회 수정을 위한 멤버 아이템 목록 조회
 	 */
 	public CursorSummary<BucketMemberItemSummary> getMemberItemsForModify(
 		final Long bucketId,

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/inventory/api/InventoryController.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/inventory/api/InventoryController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.programmers.bucketback.common.model.Hobby;
@@ -76,16 +77,19 @@ public class InventoryController {
 		return ResponseEntity.ok(response);
 	}
 
-	@Operation(summary = "인벤토리 수정을 위한 내가 리뷰한 아이템 조회")
-	@GetMapping("/inventories/{inventoryId}/myitems")
+	@Operation(summary = "인벤토리 조회와 수정을 위한 내가 리뷰한 아이템 조회")
+	@GetMapping("/inventories/myitems")
 	public ResponseEntity<InventoryGetReviewedItemResponse> getReviewedItemsForModify(
-		@PathVariable final Long inventoryId,
+		@RequestParam(required = false) final Long inventoryId,
+		@RequestParam(required = false) final String hobbyName,
 		@ModelAttribute @Valid final CursorRequest cursorRequest
 	) {
 
 		InventoryGetReviewedItemResponse response = InventoryGetReviewedItemResponse.from(
 			inventoryService.getReviewedItemsForModify(
-				inventoryId, cursorRequest.toParameters()
+				inventoryId,
+				Hobby.fromName(hobbyName),
+				cursorRequest.toParameters()
 			)
 		);
 

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/inventory/application/InventoryService.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/inventory/application/InventoryService.java
@@ -82,11 +82,17 @@ public class InventoryService {
 	 */
 	public CursorSummary<InventoryReviewItemSummary> getReviewedItemsForModify(
 		final Long inventoryId,
+		final Hobby hobby,
 		final CursorPageParameters parameters
 	) {
 		Long memberId = MemberUtils.getCurrentMemberId();
 
-		return inventoryReader.readReviewedItem(memberId, inventoryId, parameters);
+		return inventoryReader.readReviewedItem(
+			memberId,
+			inventoryId,
+			hobby,
+			parameters
+		);
 	}
 
 	private void validateDuplication(

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/domains/bucket/implementation/BucketReader.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/domains/bucket/implementation/BucketReader.java
@@ -27,9 +27,7 @@ import com.programmers.bucketback.error.EntityNotFoundException;
 import com.programmers.bucketback.error.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @Component
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -90,7 +88,6 @@ public class BucketReader {
 			itemIdsFromBucketItem = bucket.getBucketItems().stream()
 				.map(bucketItem -> bucketItem.getItem().getId())
 				.toList();
-			itemIdsFromBucketItem.forEach(System.out::println);
 		}
 
 		List<BucketMemberItemSummary> summaries = memberItemReader.readBucketMemberItem(

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/domains/bucket/implementation/BucketReader.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/domains/bucket/implementation/BucketReader.java
@@ -27,7 +27,9 @@ import com.programmers.bucketback.error.EntityNotFoundException;
 import com.programmers.bucketback.error.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -73,21 +75,28 @@ public class BucketReader {
 	public CursorSummary<BucketMemberItemSummary> readByMemberItems(
 		final Long bucketId,
 		final Long memberId,
+		final Hobby hobby,
 		final CursorPageParameters parameters
 	) {
 		int pageSize = getPageSize(parameters);
 
-		Bucket bucket = read(bucketId, memberId);
-		List<Long> itemIdsFromBucketItem = bucket.getBucketItems().stream()
-			.map(bucketItem -> bucketItem.getItem().getId())
-			.toList();
 		List<Long> itemIdsFromMemberItem = memberItemReader.readByMemberId(memberId).stream()
 			.map(memberItem -> memberItem.getItem().getId())
 			.toList();
+		List<Long> itemIdsFromBucketItem = null;
+
+		if (bucketId != null) {
+			Bucket bucket = read(bucketId, memberId);
+			itemIdsFromBucketItem = bucket.getBucketItems().stream()
+				.map(bucketItem -> bucketItem.getItem().getId())
+				.toList();
+			itemIdsFromBucketItem.forEach(System.out::println);
+		}
 
 		List<BucketMemberItemSummary> summaries = memberItemReader.readBucketMemberItem(
 			itemIdsFromBucketItem,
 			itemIdsFromMemberItem,
+			hobby,
 			memberId,
 			parameters.cursorId(),
 			pageSize

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/domains/bucket/implementation/BucketReader.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/domains/bucket/implementation/BucketReader.java
@@ -71,7 +71,7 @@ public class BucketReader {
 		return bucketItemRepository.findByBucketId(bucketId);
 	}
 
-	/** 버킷 수정을 위한 MemberItem 커서 조회 */
+	/** 버킷 조회와 수정을 위한 MemberItem 커서 조회 */
 	public CursorSummary<BucketMemberItemSummary> readByMemberItems(
 		final Long bucketId,
 		final Long memberId,

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/domains/item/implementation/ItemReader.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/domains/item/implementation/ItemReader.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.programmers.bucketback.common.model.Hobby;
 import com.programmers.bucketback.domains.inventory.model.InventoryReviewItemSummary;
 import com.programmers.bucketback.domains.item.domain.Item;
 import com.programmers.bucketback.domains.item.repository.ItemRepository;
@@ -28,12 +29,14 @@ public class ItemReader {
 	public List<InventoryReviewItemSummary> readReviewedItem(
 		final List<Long> itemIdsFromReview,
 		final List<Long> itemIdsFromInventory,
+		final Hobby hobby,
 		final String cursorId,
 		final int pageSize
 	) {
 		return itemRepository.findReviewedItemByCursor(
 			itemIdsFromReview,
 			itemIdsFromInventory,
+			hobby,
 			cursorId,
 			pageSize
 		);

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/domains/item/implementation/MemberItemReader.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/domains/item/implementation/MemberItemReader.java
@@ -50,6 +50,7 @@ public class MemberItemReader {
 	public List<BucketMemberItemSummary> readBucketMemberItem(
 		final List<Long> itemIdsFromBucketItem,
 		final List<Long> itemIdsFromMemberItem,
+		final Hobby hobby,
 		final Long memberId,
 		final String cursorId,
 		final int pageSize
@@ -57,6 +58,7 @@ public class MemberItemReader {
 		return memberItemRepository.findBucketMemberItemsByCursor(
 			itemIdsFromBucketItem,
 			itemIdsFromMemberItem,
+			hobby,
 			memberId,
 			cursorId,
 			pageSize

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/domains/item/repository/ItemRepositoryForCursor.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/domains/item/repository/ItemRepositoryForCursor.java
@@ -2,6 +2,7 @@ package com.programmers.bucketback.domains.item.repository;
 
 import java.util.List;
 
+import com.programmers.bucketback.common.model.Hobby;
 import com.programmers.bucketback.domains.inventory.model.InventoryReviewItemSummary;
 import com.programmers.bucketback.domains.item.model.ItemCursorSummary;
 
@@ -15,6 +16,7 @@ public interface ItemRepositoryForCursor {
 	List<InventoryReviewItemSummary> findReviewedItemByCursor(
 		final List<Long> itemIdsFromReview,
 		final List<Long> itemIdsFromInventory,
+		final Hobby hobby,
 		final String cursorId,
 		final int pageSize
 	);

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/domains/item/repository/MemberItemRepositoryForCursor.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/domains/item/repository/MemberItemRepositoryForCursor.java
@@ -10,6 +10,7 @@ public interface MemberItemRepositoryForCursor {
 	List<BucketMemberItemSummary> findBucketMemberItemsByCursor(
 		final List<Long> itemIdsFromBucketItem,
 		final List<Long> itemIdsFromMemberItem,
+		final Hobby hobby,
 		final Long memberId,
 		final String cursorId,
 		final int pageSize

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/domains/item/repository/MemberItemRepositoryForCursorImpl.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/domains/item/repository/MemberItemRepositoryForCursorImpl.java
@@ -32,6 +32,7 @@ public class MemberItemRepositoryForCursorImpl implements MemberItemRepositoryFo
 	public List<BucketMemberItemSummary> findBucketMemberItemsByCursor(
 		final List<Long> itemIdsFromBucketItem,
 		final List<Long> itemIdsFromMemberItem,
+		final Hobby hobby,
 		final Long memberId,
 		final String cursorId,
 		final int pageSize
@@ -41,7 +42,8 @@ public class MemberItemRepositoryForCursorImpl implements MemberItemRepositoryFo
 			.join(memberItem).on(item.id.eq(memberItem.item.id))
 			.where(
 				cursorIdConditionFromMemberItem(cursorId),
-				item.id.in(itemIdsFromMemberItem)
+				item.id.in(itemIdsFromMemberItem),
+				hobbyCondition(hobby)
 			)
 			.orderBy(new OrderSpecifier<>(Order.DESC, item.createdAt))
 			.limit(pageSize)
@@ -96,6 +98,10 @@ public class MemberItemRepositoryForCursorImpl implements MemberItemRepositoryFo
 	}
 
 	private BooleanExpression isSelected(final List<Long> itemIdsFromBucketItem) {
+		if (itemIdsFromBucketItem == null) {
+			return Expressions.asBoolean(false).isTrue();
+		}
+
 		return new CaseBuilder()
 			.when(memberItem.item.id.in(itemIdsFromBucketItem))
 			.then(true)


### PR DESCRIPTION
## 📌 PR 종류

어떤 종류의 PR인지 아래 항목 중에 체크 해주세요.
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [ ]  🐛 버그 수정
- [ ]  ✨ 기능 추가
- [ ]  **✅** 테스트 추가
- [ ]  🎨 코드 스타일 변경 (formatting, local variables)
- [x]  🔨 리팩토링 (기능 변경 X)
- [ ]  **💚** 빌드 관련 수정
- [ ]  **📝** 문서 내용 수정
- [ ]  그 외, 어떤 종류인지 기입 바람:
<br>

## 📌 어떤 기능이 추가 되었나요?

<!--어떤 기능이 추가 되었는지 설명해주시고 관련된 지라 이슈 넘버를 추가 해주세요 -->

### Issue Number

288

### 기능 설명

1. 인벤토리와 버킷 경로 수정 33, 49 api (id값을 requestparam으로 받도록 변경, hobby를 requestparam으로 받도록 추가)
2. id값을 입력하는 경우는 수정하는 경우, 그렇지 않은 경우는 생성하는 경우로 생각한다.
3. 취미를 입력하는 경우는 취미별로 조회, 그렇지 않은 경우는 전체 조회를 할수 있도록 설정함

<br>

## 📌 기존에 있던 기능에 영향을 주나요?

- [x]  네
- [ ]  아니요

<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->
