### PR TITLE
[OMCT-324] VoteManager 단위 테스트 추가

### DIFF
--- a/bucketback-domain/src/main/java/com/programmers/bucketback/domains/vote/domain/Voter.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/domains/vote/domain/Voter.java
@@ -50,5 +50,6 @@ public class Voter extends BaseEntity {
 
 	public void participate(final Long itemId) {
 		this.itemId = itemId;
+		this.vote.addVoter(this);
 	}
 }

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/domains/vote/implementation/VoteManager.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/domains/vote/implementation/VoteManager.java
@@ -25,7 +25,6 @@ public class VoteManager {
 		final Voter voter = voterReader.read(vote, memberId, itemId);
 
 		voter.participate(itemId);
-		vote.addVoter(voter);
 	}
 
 	@Transactional

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/domains/vote/implementation/VoteManager.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/domains/vote/implementation/VoteManager.java
@@ -22,8 +22,7 @@ public class VoteManager {
 		final Long memberId,
 		final Long itemId
 	) {
-		final Voter voter = voterReader.read(vote, memberId)
-			.orElseGet(() -> new Voter(vote, memberId, itemId));
+		final Voter voter = voterReader.read(vote, memberId, itemId);
 
 		voter.participate(itemId);
 		vote.addVoter(voter);

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/domains/vote/implementation/VoterReader.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/domains/vote/implementation/VoterReader.java
@@ -24,4 +24,14 @@ public class VoterReader {
 	) {
 		return voterRepository.findByVoteAndMemberId(vote, memberId);
 	}
+
+	@Transactional(readOnly = true)
+	public Voter read(
+		final Vote vote,
+		final Long memberId,
+		final Long itemId
+	) {
+		return voterRepository.findByVoteAndMemberId(vote, memberId)
+			.orElseGet(() -> new Voter(vote, memberId, itemId));
+	}
 }

--- a/bucketback-domain/src/test/java/com/programmers/bucketback/domains/vote/implementation/VoteManagerTest.java
+++ b/bucketback-domain/src/test/java/com/programmers/bucketback/domains/vote/implementation/VoteManagerTest.java
@@ -55,7 +55,7 @@ class VoteManagerTest {
 
 	@Nested
 	@DisplayName("투표에")
-	class participateTest {
+	class ParticipateTest {
 
 		@Test
 		@DisplayName("처음 참여한다.")

--- a/bucketback-domain/src/test/java/com/programmers/bucketback/domains/vote/implementation/VoteManagerTest.java
+++ b/bucketback-domain/src/test/java/com/programmers/bucketback/domains/vote/implementation/VoteManagerTest.java
@@ -29,6 +29,30 @@ class VoteManagerTest {
 	@Mock
 	private VoterRepository voterRepository;
 
+	@Test
+	@DisplayName("투표를 취소한다.")
+	void cancelTest() {
+		// given
+		final Vote vote = VoteBuilder.build();
+		final Long memberId = 1L;
+		final Voter voter = VoterBuilder.build(vote, memberId, 1L);
+
+		vote.addVoter(voter);
+
+		will(invocation -> {
+			final Vote givenVote = invocation.getArgument(0);
+			final Long givenMemberId = invocation.getArgument(1);
+			givenVote.getVoters().removeIf(savedVoter -> savedVoter.getMemberId().equals(givenMemberId));
+			return null;
+		}).given(voterRepository).deleteByVoteAndMemberId(any(Vote.class), anyLong());
+
+		// when
+		voteManager.cancel(vote, memberId);
+
+		// then
+		assertThat(vote.getVoters()).doesNotContain(voter);
+	}
+
 	@Nested
 	@DisplayName("투표에")
 	class participateTest {

--- a/bucketback-domain/src/test/java/com/programmers/bucketback/domains/vote/implementation/VoteManagerTest.java
+++ b/bucketback-domain/src/test/java/com/programmers/bucketback/domains/vote/implementation/VoteManagerTest.java
@@ -1,0 +1,83 @@
+package com.programmers.bucketback.domains.vote.implementation;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.programmers.bucketback.domains.vote.domain.Vote;
+import com.programmers.bucketback.domains.vote.domain.VoteBuilder;
+import com.programmers.bucketback.domains.vote.domain.Voter;
+import com.programmers.bucketback.domains.vote.domain.VoterBuilder;
+import com.programmers.bucketback.domains.vote.repository.VoterRepository;
+
+@ExtendWith(MockitoExtension.class)
+class VoteManagerTest {
+
+	@InjectMocks
+	private VoteManager voteManager;
+
+	@Mock
+	private VoterReader voterReader;
+
+	@Mock
+	private VoterRepository voterRepository;
+
+	@Nested
+	@DisplayName("투표에")
+	class participateTest {
+
+		@Test
+		@DisplayName("처음 참여한다.")
+		void participateFirstTest() {
+			// given
+			final Vote vote = VoteBuilder.build();
+			final Long memberId = 1L;
+			final Long itemId = 1L;
+			final Voter voter = VoterBuilder.build(vote, memberId, itemId);
+
+			given(voterReader.read(any(Vote.class), anyLong(), anyLong()))
+				.willReturn(voter);
+
+			// when
+			voteManager.participate(vote, memberId, itemId);
+
+			// then
+			assertThat(voter.getVote()).isEqualTo(vote);
+			assertThat(voter.getMemberId()).isEqualTo(memberId);
+			assertThat(voter.getItemId()).isEqualTo(itemId);
+			assertThat(vote.getVoters()).containsOnly(voter);
+		}
+
+		@Test
+		@DisplayName("재참여한다.")
+		void reParticipateTest() {
+			// given
+			final Vote vote = VoteBuilder.build();
+			final Long memberId = 1L;
+			final Long originSelectedItemId = 1L;
+			final Long newSelectedItemId = 2L;
+			final Voter voter = VoterBuilder.build(vote, memberId, originSelectedItemId);
+
+			vote.addVoter(voter);
+
+			given(voterReader.read(any(Vote.class), anyLong(), anyLong()))
+				.willReturn(voter);
+
+			// when
+			voteManager.participate(vote, memberId, newSelectedItemId);
+
+			// then
+			assertThat(voter.getVote()).isEqualTo(vote);
+			assertThat(voter.getMemberId()).isEqualTo(memberId);
+			assertThat(voter.getItemId()).isEqualTo(newSelectedItemId);
+			assertThat(vote.getVoters()).containsOnly(voter);
+		}
+	}
+}

--- a/bucketback-domain/src/testFixtures/java/com/programmers/bucketback/domains/vote/domain/VoterBuilder.java
+++ b/bucketback-domain/src/testFixtures/java/com/programmers/bucketback/domains/vote/domain/VoterBuilder.java
@@ -16,26 +16,29 @@ public class VoterBuilder {
 		final Long itemId
 	) {
 		return LongStream.range(0, size)
-			.mapToObj(i -> VoterBuilder.build(i + 1, vote, i + 1, itemId))
+			.mapToObj(i -> {
+				Voter voter = VoterBuilder.build(vote, i + 1, itemId);
+				setVoterId(voter, i + 1);
+				return voter;
+			})
 			.toList();
 	}
 
 	public static Voter build(
-		final Long id,
 		final Vote vote,
 		final Long memberId,
 		final Long itemId
 	) {
 		Voter voter = new Voter(vote, memberId, itemId);
 
-		setVoterId(id, voter);
+		setVoterId(voter, 1L);
 
 		return voter;
 	}
 
 	private static void setVoterId(
-		final Long id,
-		final Voter voter
+		final Voter voter,
+		final Long id
 	) {
 		ReflectionTestUtils.setField(
 			voter,


### PR DESCRIPTION
## 📌 PR 종류

어떤 종류의 PR인지 아래 항목 중에 체크 해주세요.
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [ ]  🐛 버그 수정
- [ ]  ✨ 기능 추가
- [x]  **✅** 테스트 추가
- [ ]  🎨 코드 스타일 변경 (formatting, local variables)
- [x]  🔨 리팩토링 (기능 변경 X)
- [ ]  **💚** 빌드 관련 수정
- [ ]  **📝** 문서 내용 수정
- [ ]  그 외, 어떤 종류인지 기입 바람:
<br>

## 📌 어떤 기능이 추가 되었나요?

<!--어떤 기능이 추가 되었는지 설명해주시고 관련된 지라 이슈 넘버를 추가 해주세요 -->

### Issue Number

OMCT-324

### 투표 취소 테스트
- `deleteByVoteAndMemberId` 메서드가 실행될 때 주어진 vote의 voters 리스트에서 해당 voter를 삭제하도록 하고, voters 리스트에서 없다는 것을 통해 테스트를 검증하였습니다.

### 투표 참여 테스트
- 처음 투표를 참여할 때는 생성된 voter의 정보가 주어진 투표 정보들과 같은지 비교하였습니다.
- 투표 재참여 테스트는 기존의 투표자의 ItemId가 새로 선택한 ItemId와 같은지, 나머지 투표 정보들은 그대로인지 비교하여 검증하였습니다.

<br>

## 📌 기존에 있던 기능에 영향을 주나요?

- [ ]  네
- [x]  아니요

<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->
