### PR TITLE
[OMCT-331] 아이템 아이디 목록을 받아서 삭제할 수 있도록 기능 추가

### DIFF
--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/item/api/ItemController.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/item/api/ItemController.java
@@ -15,6 +15,7 @@ import com.programmers.bucketback.common.cursor.CursorSummary;
 import com.programmers.bucketback.common.model.Hobby;
 import com.programmers.bucketback.domains.item.api.dto.request.ItemEnrollRequest;
 import com.programmers.bucketback.domains.item.api.dto.request.MemberItemAddRequest;
+import com.programmers.bucketback.domains.item.api.dto.request.MemberItemDeleteRequest;
 import com.programmers.bucketback.domains.item.api.dto.response.ItemAddResponse;
 import com.programmers.bucketback.domains.item.api.dto.response.ItemEnrollResponse;
 import com.programmers.bucketback.domains.item.api.dto.response.ItemGetByCursorResponse;
@@ -73,9 +74,11 @@ public class ItemController {
 	}
 
 	@Operation(summary = "나의 아이템 목록에서 삭제", description = "itemId을 이용하여 나의 아이템 목록에서 삭제 합니다.")
-	@DeleteMapping("/myitems/{itemId}")
-	public ResponseEntity<Void> deleteMyItem(@PathVariable final Long itemId) {
-		itemService.removeMemberItem(itemId);
+	@DeleteMapping("/myitems")
+	public ResponseEntity<Void> deleteMyItem(@ModelAttribute @Valid final MemberItemDeleteRequest request) {
+		itemService.removeMemberItems(
+			request.toItemRemovalList()
+		);
 
 		return ResponseEntity.ok().build();
 	}

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/item/api/dto/request/MemberItemDeleteRequest.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/item/api/dto/request/MemberItemDeleteRequest.java
@@ -1,0 +1,19 @@
+package com.programmers.bucketback.domains.item.api.dto.request;
+
+import java.util.List;
+
+import com.programmers.bucketback.common.model.ItemRemovalList;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+public record MemberItemDeleteRequest(
+
+	@Schema(description = "여러 아이템 id", example = "1, 2, 3")
+	@NotNull(message = "아이템 목록은 필수 값 입니다.")
+	List<Long> itemIds
+) {
+	public ItemRemovalList toItemRemovalList() {
+		return new ItemRemovalList(itemIds);
+	}
+}

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/item/application/ItemService.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/item/application/ItemService.java
@@ -8,6 +8,7 @@ import com.programmers.bucketback.common.cursor.CursorPageParameters;
 import com.programmers.bucketback.common.cursor.CursorSummary;
 import com.programmers.bucketback.common.model.Hobby;
 import com.programmers.bucketback.common.model.ItemIdRegistry;
+import com.programmers.bucketback.common.model.ItemRemovalList;
 import com.programmers.bucketback.domains.item.application.dto.ItemAddServiceResponse;
 import com.programmers.bucketback.domains.item.application.dto.ItemGetNamesServiceResponse;
 import com.programmers.bucketback.domains.item.application.dto.ItemGetServiceResponse;
@@ -67,10 +68,13 @@ public class ItemService {
 			.build();
 	}
 
-	public void removeMemberItem(final Long itemId) {
+	public void removeMemberItems(final ItemRemovalList itemRemovalList) {
 		Long memberId = memberUtils.getCurrentMemberId();
-		MemberItem memberItem = memberItemReader.read(itemId, memberId);
-		memberItemRemover.remove(memberItem.getId());
+
+		for (Long itemId : itemRemovalList.itemIds()) {
+			MemberItem memberItem = memberItemReader.read(itemId, memberId);
+			memberItemRemover.remove(memberItem.getId());
+		}
 	}
 
 	public ItemGetNamesServiceResponse getItemNamesByKeyword(final String keyword) {

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/common/model/ItemRemovalList.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/common/model/ItemRemovalList.java
@@ -1,0 +1,8 @@
+package com.programmers.bucketback.common.model;
+
+import java.util.List;
+
+public record ItemRemovalList(
+	List<Long> itemIds
+) {
+}


### PR DESCRIPTION
## 📌 PR 종류

어떤 종류의 PR인지 아래 항목 중에 체크 해주세요.
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [ ]  🐛 버그 수정
- [x]  ✨ 기능 추가
- [ ]  **✅** 테스트 추가
- [ ]  🎨 코드 스타일 변경 (formatting, local variables)
- [ ]  🔨 리팩토링 (기능 변경 X)
- [ ]  **💚** 빌드 관련 수정
- [ ]  **📝** 문서 내용 수정
- [ ]  그 외, 어떤 종류인지 기입 바람:
<br>

## 📌 어떤 기능이 추가 되었나요?

<!--어떤 기능이 추가 되었는지 설명해주시고 관련된 지라 이슈 넘버를 추가 해주세요 -->
아이템 아이디 목록을 받아서 삭제할 수 있도록 기능 추가

### Issue Number

[OMCT-331]

### 기능 설명

아이템 아이디 목록을 받아서 삭제할 수 있도록 기능 추가
- 내부적으로는 단일 삭제 메서드를 for문으로 호출하고 있습니다. 이 부분은 추후 기능개선을 할 때 쿼리 한번에 삭제될 수 있도록 수정할 예정 입니다!
 
<br>

## 📌 기존에 있던 기능에 영향을 주나요?

- [ ]  네
- [x]  아니요

<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->


[OMCT-331]: https://ohmycourse.atlassian.net/browse/OMCT-331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ