### PR TITLE
[NO-JIRA] 아이템 목록 조회 좋아요 누른 피드 보기 버그 수정

### DIFF
--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/feed/api/FeedController.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/feed/api/FeedController.java
@@ -83,9 +83,9 @@ public class FeedController {
 	@Operation(summary = "피드 목록 조회", description = "hobbyName, nickname, sortCondition, CursorRequest을 이용하여 피드 목록 조회 합니다.")
 	@GetMapping
 	public ResponseEntity<FeedGetByCursorResponse> getFeedByCursor(
-		@RequestParam final String hobbyName,
+		@RequestParam(required = false) final String hobbyName,
 		@RequestParam(required = false) final String nickname,
-		@RequestParam(required = false) final boolean myPageOwnerLikeFeeds,
+		@RequestParam(required = false) final boolean onlyNicknameLikeFeeds,
 		@RequestParam(required = false) final String sortCondition,
 		@ModelAttribute @Valid final CursorRequest request
 	) {
@@ -94,7 +94,7 @@ public class FeedController {
 		CursorSummary<FeedCursorSummaryLike> cursorSummary = feedService.getFeedByCursor(
 			hobby,
 			nickname,
-			myPageOwnerLikeFeeds,
+			onlyNicknameLikeFeeds,
 			sortCondition,
 			request.toParameters()
 		);

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/feed/application/FeedService.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/feed/application/FeedService.java
@@ -52,21 +52,21 @@ public class FeedService {
 	public CursorSummary<FeedCursorSummaryLike> getFeedByCursor(
 		final Hobby hobby,
 		final String nickName,
-		final boolean myPageOwnerLikeFeeds,
+		final boolean onlyNicknameLikeFeeds,
 		final String sortCondition,
 		final CursorPageParameters parameters
 	) {
 		FeedSortCondition feedSortCondition = FeedSortCondition.from(sortCondition);
 		Long loginMemberId = memberUtils.getCurrentMemberId();
 
-		if (myPageOwnerLikeFeeds && nickName == null) {
+		if (onlyNicknameLikeFeeds && nickName == null) {
 			throw new BusinessException(ErrorCode.FEED_BAD_LIKE_ONLY_REQUEST);
 		}
 
 		return feedCursorReader.getFeedByCursor(
 			hobby,
 			nickName,
-			myPageOwnerLikeFeeds,
+			onlyNicknameLikeFeeds,
 			loginMemberId,
 			feedSortCondition,
 			parameters

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/member/api/MemberController.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/member/api/MemberController.java
@@ -2,7 +2,6 @@ package com.programmers.bucketback.domains.member.api;
 
 import java.io.IOException;
 
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -34,7 +33,6 @@ import com.programmers.bucketback.domains.member.model.MyPage;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -120,13 +118,10 @@ public class MemberController {
 	@Operation(summary = "마이페이지 조회", description = "닉네임을 이용하여 마이페이지를 조회합니다.")
 	@GetMapping("/{nickname}")
 	public ResponseEntity<MemberGetMyPageResponse> getMyPage(
-		@PathVariable final String nickname,
-		final HttpServletResponse servletResponse
+		@PathVariable final String nickname
 	) {
 		MyPage myPage = memberService.getMyPage(nickname);
 		MemberGetMyPageResponse response = MemberGetMyPageResponse.from(myPage);
-		servletResponse.setHeader(HttpHeaders.CACHE_CONTROL, "no-cache, no-store, max-age=0, must-revalidate");
-		servletResponse.setHeader("Pragma", "no-cache");
 
 		return ResponseEntity.ok(response);
 	}

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/member/api/MemberController.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/member/api/MemberController.java
@@ -2,6 +2,7 @@ package com.programmers.bucketback.domains.member.api;
 
 import java.io.IOException;
 
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -33,6 +34,7 @@ import com.programmers.bucketback.domains.member.model.MyPage;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -118,10 +120,13 @@ public class MemberController {
 	@Operation(summary = "마이페이지 조회", description = "닉네임을 이용하여 마이페이지를 조회합니다.")
 	@GetMapping("/{nickname}")
 	public ResponseEntity<MemberGetMyPageResponse> getMyPage(
-		@PathVariable String nickname
+		@PathVariable final String nickname,
+		final HttpServletResponse servletResponse
 	) {
 		MyPage myPage = memberService.getMyPage(nickname);
 		MemberGetMyPageResponse response = MemberGetMyPageResponse.from(myPage);
+		servletResponse.setHeader(HttpHeaders.CACHE_CONTROL, "no-cache, no-store, max-age=0, must-revalidate");
+		servletResponse.setHeader("Pragma", "no-cache");
 
 		return ResponseEntity.ok(response);
 	}

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/domains/feed/implementation/FeedCursorReader.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/domains/feed/implementation/FeedCursorReader.java
@@ -32,17 +32,17 @@ public class FeedCursorReader {
 	public CursorSummary<FeedCursorSummaryLike> getFeedByCursor(
 		final Hobby hobby,
 		final String nickname,
-		final boolean myPageOwnerLikeFeeds,
+		final boolean onlyNicknameLikeFeeds,
 		final Long loginMemberId,
 		final FeedSortCondition sortCondition,
 		final CursorPageParameters parameters
 	) {
 		int pageSize = getPageSizeByParameter(parameters);
-		Long myPageMemberId = getMemberIdByNickname(nickname);
+		Long nicknameMemberId = getMemberIdByNickname(nickname);
 
 		List<FeedCursorSummary> feedCursorSummaries = feedRepository.findAllByCursor(
-			myPageMemberId,
-			myPageOwnerLikeFeeds,
+			nicknameMemberId,
+			onlyNicknameLikeFeeds,
 			hobby,
 			sortCondition,
 			parameters.cursorId(),

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/domains/feed/implementation/FeedCursorReader.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/domains/feed/implementation/FeedCursorReader.java
@@ -50,14 +50,13 @@ public class FeedCursorReader {
 		);
 
 		List<FeedCursorSummaryLike> feedCursorSummaryLikes = feedCursorSummaries.stream().map(
-			item -> {
+			feedCursorSummary -> {
 				boolean isLike = feedLikeRepository.existsByMemberIdAndFeed(
 					loginMemberId,
-					feedReader.read(item.feedId()
-					)
+					feedReader.read(feedCursorSummary.feedId())
 				);
 
-				return item.of(isLike);
+				return feedCursorSummary.of(isLike);
 			}
 		).toList();
 

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/domains/feed/repository/FeedRepositoryForCursor.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/domains/feed/repository/FeedRepositoryForCursor.java
@@ -8,8 +8,8 @@ import com.programmers.bucketback.domains.feed.model.FeedSortCondition;
 
 public interface FeedRepositoryForCursor {
 	List<FeedCursorSummary> findAllByCursor(
-		final Long myPageMemberId,
-		final boolean myPageOwnerLikeFeeds,
+		final Long nicknameMemberId,
+		final boolean onlyNicknameLikeFeeds,
 		final Hobby hobby,
 		final FeedSortCondition feedSortCondition,
 		final String cursorId,

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/domains/feed/repository/FeedRepositoryForCursorImpl.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/domains/feed/repository/FeedRepositoryForCursorImpl.java
@@ -33,8 +33,8 @@ public class FeedRepositoryForCursorImpl implements FeedRepositoryForCursor {
 	private final JPAQueryFactory jpaQueryFactory;
 
 	public List<FeedCursorSummary> findAllByCursor(
-		final Long myPageMemberId,
-		final boolean myPageOwnerLikeFeeds,
+		final Long nicknameMemberId,
+		final boolean onlyNicknameLikeFeeds,
 		final Hobby hobby,
 		final FeedSortCondition feedSortCondition,
 		final String cursorId,
@@ -44,16 +44,16 @@ public class FeedRepositoryForCursorImpl implements FeedRepositoryForCursor {
 			.from(feed)
 			.where(
 				feed.bucketInfo.hobby.eq(hobby),
-				eqMemberId(myPageMemberId),
+				eqMemberId(nicknameMemberId),
 				lessThanNextCursorId(feedSortCondition, cursorId)
 			).limit(pageSize)
 			.fetch();
 
-		if (myPageOwnerLikeFeeds) {
+		if (onlyNicknameLikeFeeds) {
 			feedIds = jpaQueryFactory.select(feedLike.feed.id)
 				.from(feedLike)
 				.where(
-					eqLikeMemberId(myPageMemberId),
+					eqLikeMemberId(nicknameMemberId),
 					feedLike.feed.id.in(feedIds)
 				).fetch();
 		}
@@ -63,7 +63,7 @@ public class FeedRepositoryForCursorImpl implements FeedRepositoryForCursor {
 			.where(
 				feedItem.feed.id.in(feedIds)
 			)
-			.join(member).on(eqMemberIdToJoin(myPageMemberId))
+			.join(member).on(eqMemberIdToJoin(nicknameMemberId))
 			.orderBy(feedSort(feedSortCondition), feed.id.desc())
 			.transform(
 				groupBy(feed.id)

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/domains/feed/repository/FeedRepositoryForCursorImpl.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/domains/feed/repository/FeedRepositoryForCursorImpl.java
@@ -44,7 +44,7 @@ public class FeedRepositoryForCursorImpl implements FeedRepositoryForCursor {
 			.from(feed)
 			.where(
 				feed.bucketInfo.hobby.eq(hobby),
-				eqMemberId(nicknameMemberId),
+				eqMemberId(nicknameMemberId, onlyNicknameLikeFeeds),
 				lessThanNextCursorId(feedSortCondition, cursorId)
 			).limit(pageSize)
 			.fetch();
@@ -117,12 +117,19 @@ public class FeedRepositoryForCursorImpl implements FeedRepositoryForCursor {
 		return member.id.eq(feedItem.feed.memberId);
 	}
 
-	private BooleanExpression eqMemberId(final Long memberId) {
-		if (memberId == null) {
+	private BooleanExpression eqMemberId(
+		final Long nicknameMemberId,
+		final boolean onlyNicknameLikeFeeds
+	) {
+		if (onlyNicknameLikeFeeds) {
 			return null;
 		}
 
-		return feed.memberId.eq(memberId);
+		if (nicknameMemberId == null) {
+			return null;
+		}
+
+		return feed.memberId.eq(nicknameMemberId);
 	}
 
 	private BooleanExpression lessThanNextCursorId(


### PR DESCRIPTION
## 📌 PR 종류

어떤 종류의 PR인지 아래 항목 중에 체크 해주세요.
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [x]  🐛 버그 수정
- [ ]  ✨ 기능 추가
- [ ]  **✅** 테스트 추가
- [ ]  🎨 코드 스타일 변경 (formatting, local variables)
- [ ]  🔨 리팩토링 (기능 변경 X)
- [ ]  **💚** 빌드 관련 수정
- [ ]  **📝** 문서 내용 수정
- [ ]  그 외, 어떤 종류인지 기입 바람:
<br>

## 📌 어떤 기능이 추가 되었나요?

<!--어떤 기능이 추가 되었는지 설명해주시고 관련된 지라 이슈 넘버를 추가 해주세요 -->

### Issue Number

[NO-JIRA]

### 기능 설명

#### nickname이 좋아요 누른 피드를 요청할 때 nickname이 작성한 피드만 보이는 버그 수정
- 요구사항 혼동으로 인한 잘못된 변수명 수정 a4e27d8fad47304411ee5413f2506e39530ad54a
- nickname이 좋아요 누른 피드만 볼 수 있도록 onlyNicknameLikeFeeds이 true일 경우 nickname이 올린 피드만 볼 수 있게 하는 기능을 넘기도록 수정 23dc3dcd602ad27dcf6d03c6f02fe26267573d4b


## 📌 기존에 있던 기능에 영향을 주나요?

- [ ]  네
- [x]  아니요

<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->
