### PR TITLE
[NO-JIRA] 회원 프로필 이미지 주소 대신 이미지 이름으로 저장하도록 변경

### DIFF
--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/member/application/MemberService.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/member/application/MemberService.java
@@ -1,6 +1,7 @@
 package com.programmers.bucketback.domains.member.application;
 
 import java.io.IOException;
+import java.util.UUID;
 
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -28,7 +29,6 @@ import lombok.RequiredArgsConstructor;
 public class MemberService {
 
 	public static final String DIRECTORY = "bucketback-static";
-	public static final String BASE_EXTENSION = ".png";
 
 	private final MemberAppender memberAppender;
 	private final MemberReader memberReader;
@@ -110,16 +110,16 @@ public class MemberService {
 
 	public void updateProfileImage(final MultipartFile multipartFile) throws IOException {
 		final Member member = memberUtils.getCurrentMember();
-		final String profileImage = member.getId() + BASE_EXTENSION;
 
-		s3Manager.deleteFile(profileImage, DIRECTORY);
+		s3Manager.deleteFile(DIRECTORY, member.getProfileImage());
 
 		if (multipartFile == null) {
 			memberRemover.removeProfileImage(member);
 			return;
 		}
 
+		final String profileImage = UUID.randomUUID().toString();
 		s3Manager.uploadFile(multipartFile, DIRECTORY, profileImage);
-		memberModifier.modifyProfileImage(member, DIRECTORY, profileImage);
+		memberModifier.modifyProfileImage(member, profileImage);
 	}
 }

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/domains/member/domain/Member.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/domains/member/domain/Member.java
@@ -27,6 +27,8 @@ import lombok.NoArgsConstructor;
 @Table(name = "members")
 public class Member extends BaseEntity {
 
+	public static final String BASE_PROFILE_IMAGE_URL = "https://team-02-bucket.s3.ap-northeast-2.amazonaws.com/bucketback-static";
+
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "id")
@@ -87,6 +89,14 @@ public class Member extends BaseEntity {
 		}
 
 		return introduction.getIntroduction();
+	}
+
+	public String getProfileImage() {
+		return this.profileImage;
+	}
+
+	public String getProfileImageUrl() {
+		return BASE_PROFILE_IMAGE_URL + profileImage;
 	}
 
 	public void delete() {

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/domains/member/implementation/MemberModifier.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/domains/member/implementation/MemberModifier.java
@@ -39,11 +39,8 @@ public class MemberModifier {
 	@Transactional
 	public void modifyProfileImage(
 		final Member member,
-		final String directory,
 		final String profileImage
 	) {
-		final String imagePath = IMAGE_BASE_PATH + directory + "/" + profileImage;
-
-		member.updateProfileImage(imagePath);
+		member.updateProfileImage(profileImage);
 	}
 }

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/domains/member/model/MemberInfo.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/domains/member/model/MemberInfo.java
@@ -26,7 +26,7 @@ public record MemberInfo(
 		return new MemberInfo(
 			member.getId(),
 			member.getNickname(),
-			member.getProfileImage(),
+			member.getProfileImageUrl(),
 			member.getLevelPoint()
 		);
 	}

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/domains/member/model/MemberProfile.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/domains/member/model/MemberProfile.java
@@ -16,7 +16,7 @@ public record MemberProfile(
 		return MemberProfile.builder()
 			.memberId(member.getId())
 			.nickname(member.getNickname())
-			.profileImage(member.getProfileImage())
+			.profileImage(member.getProfileImageUrl())
 			.level(member.getLevel())
 			.introduction(member.getIntroduction())
 			.build();


### PR DESCRIPTION
## 📌 PR 종류

어떤 종류의 PR인지 아래 항목 중에 체크 해주세요.
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [ ]  🐛 버그 수정
- [ ]  ✨ 기능 추가
- [ ]  **✅** 테스트 추가
- [ ]  🎨 코드 스타일 변경 (formatting, local variables)
- [x]  🔨 리팩토링 (기능 변경 X)
- [ ]  **💚** 빌드 관련 수정
- [ ]  **📝** 문서 내용 수정
- [ ]  그 외, 어떤 종류인지 기입 바람:
<br>

## 📌 어떤 기능이 추가 되었나요?

<!--어떤 기능이 추가 되었는지 설명해주시고 관련된 지라 이슈 넘버를 추가 해주세요 -->

### Issue Number

NO-JIRA

### 기능 설명

**기존 방식**
- 프로필 이미지를 S3 버킷 주소를 그대로 저장
- 프로필 이미지 이름은 회원 id로 생성

**변경된 방식**
- 프로필 이미지를 이름 그대로 저장하고, 주소를 얻는 게더 메서드 따로 생성
- 프로필 이미지 이름은 UUID로 생성

<br>

## 📌 기존에 있던 기능에 영향을 주나요?

- [ ]  네
- [x]  아니요

<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->
