### PR TITLE
[NO-JIRA] 커서 목록조회 : 총 개수를 read 해오는 반환값 추가

### DIFF
--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/bucket/api/dto/response/BucketGetByCursorResponse.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/bucket/api/dto/response/BucketGetByCursorResponse.java
@@ -2,17 +2,19 @@ package com.programmers.bucketback.domains.bucket.api.dto.response;
 
 import java.util.List;
 
-import com.programmers.bucketback.common.cursor.CursorSummary;
+import com.programmers.bucketback.domains.bucket.application.dto.response.BucketGetCursorServiceResponse;
 import com.programmers.bucketback.domains.bucket.model.BucketSummary;
 
 public record BucketGetByCursorResponse(
 	String nextCursorId,
+	int totalBucketCount,
 	List<BucketSummary> buckets
 ) {
-	public static BucketGetByCursorResponse from(final CursorSummary<BucketSummary> summary) {
+	public static BucketGetByCursorResponse from(final BucketGetCursorServiceResponse response) {
 		return new BucketGetByCursorResponse(
-			summary.nextCursorId(),
-			summary.summaries()
+			response.cursorSummary().nextCursorId(),
+			response.totalBucketCount(),
+			response.cursorSummary().summaries()
 		);
 	}
 }

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/bucket/api/dto/response/BucketGetMemberItemResponse.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/bucket/api/dto/response/BucketGetMemberItemResponse.java
@@ -2,19 +2,21 @@ package com.programmers.bucketback.domains.bucket.api.dto.response;
 
 import java.util.List;
 
-import com.programmers.bucketback.common.cursor.CursorSummary;
+import com.programmers.bucketback.domains.bucket.application.dto.response.BucketGetMemberItemServiceResponse;
 import com.programmers.bucketback.domains.bucket.model.BucketMemberItemSummary;
 
 public record BucketGetMemberItemResponse(
 	String nextCursorId,
 	int totalCount,
+	int totalMemberItemCount,
 	List<BucketMemberItemSummary> memberItems
 ) {
-	public static BucketGetMemberItemResponse from(final CursorSummary<BucketMemberItemSummary> summary) {
+	public static BucketGetMemberItemResponse from(final BucketGetMemberItemServiceResponse response) {
 		return new BucketGetMemberItemResponse(
-			summary.nextCursorId(),
-			summary.summaryCount(),
-			summary.summaries()
+			response.cursorSummary().nextCursorId(),
+			response.cursorSummary().summaryCount(),
+			response.totalMemberItemCount(),
+			response.cursorSummary().summaries()
 		);
 	}
 }

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/bucket/application/BucketService.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/bucket/application/BucketService.java
@@ -79,7 +79,7 @@ public class BucketService {
 	) {
 		Long memberId = memberUtils.getCurrentMemberId();
 
-		int totalMemberItemCount = memberItemReader.countByMemberId(memberId);
+		int totalMemberItemCount = memberItemReader.countByMemberIdAndHobby(memberId, hobby);
 		CursorSummary<BucketMemberItemSummary> cursorSummary = bucketReader.readByMemberItems(
 			bucketId,
 			memberId,

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/bucket/application/BucketService.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/bucket/application/BucketService.java
@@ -6,6 +6,7 @@ import com.programmers.bucketback.common.cursor.CursorPageParameters;
 import com.programmers.bucketback.common.cursor.CursorSummary;
 import com.programmers.bucketback.common.model.Hobby;
 import com.programmers.bucketback.common.model.ItemIdRegistry;
+import com.programmers.bucketback.domains.bucket.application.dto.response.BucketGetCursorServiceResponse;
 import com.programmers.bucketback.domains.bucket.domain.BucketInfo;
 import com.programmers.bucketback.domains.bucket.implementation.BucketAppender;
 import com.programmers.bucketback.domains.bucket.implementation.BucketModifier;
@@ -93,14 +94,21 @@ public class BucketService {
 	/**
 	 * 버킷 커서 조회
 	 */
-	public CursorSummary<BucketSummary> getBucketsByCursor(
+	public BucketGetCursorServiceResponse getBucketsByCursor(
 		final String nickname,
 		final Hobby hobby,
 		final CursorPageParameters parameters
 	) {
 		Long memberId = memberReader.readByNickname(nickname).getId();
 
-		return bucketReader.readByCursor(memberId, hobby, parameters);
+		int totalBucketCount = bucketReader.countByMemberId(memberId);
+		CursorSummary<BucketSummary> cursorSummary = bucketReader.readByCursor(
+			memberId,
+			hobby,
+			parameters
+		);
+
+		return BucketGetCursorServiceResponse.of(cursorSummary, totalBucketCount);
 	}
 
 	private void validateExceedBudget(

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/bucket/application/BucketService.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/bucket/application/BucketService.java
@@ -87,7 +87,7 @@ public class BucketService {
 			parameters
 		);
 
-		return BucketGetMemberItemServiceResponse.of(cursorSummary, totalMemberItemCount);
+		return new BucketGetMemberItemServiceResponse(cursorSummary, totalMemberItemCount);
 	}
 
 	/**
@@ -114,7 +114,7 @@ public class BucketService {
 			parameters
 		);
 
-		return BucketGetCursorServiceResponse.of(cursorSummary, totalBucketCount);
+		return new BucketGetCursorServiceResponse(cursorSummary, totalBucketCount);
 	}
 
 	private void validateExceedBudget(

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/bucket/application/BucketService.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/bucket/application/BucketService.java
@@ -7,6 +7,7 @@ import com.programmers.bucketback.common.cursor.CursorSummary;
 import com.programmers.bucketback.common.model.Hobby;
 import com.programmers.bucketback.common.model.ItemIdRegistry;
 import com.programmers.bucketback.domains.bucket.application.dto.response.BucketGetCursorServiceResponse;
+import com.programmers.bucketback.domains.bucket.application.dto.response.BucketGetMemberItemServiceResponse;
 import com.programmers.bucketback.domains.bucket.domain.BucketInfo;
 import com.programmers.bucketback.domains.bucket.implementation.BucketAppender;
 import com.programmers.bucketback.domains.bucket.implementation.BucketModifier;
@@ -16,6 +17,7 @@ import com.programmers.bucketback.domains.bucket.model.BucketGetServiceResponse;
 import com.programmers.bucketback.domains.bucket.model.BucketMemberItemSummary;
 import com.programmers.bucketback.domains.bucket.model.BucketSummary;
 import com.programmers.bucketback.domains.item.implementation.ItemReader;
+import com.programmers.bucketback.domains.item.implementation.MemberItemReader;
 import com.programmers.bucketback.domains.member.implementation.MemberReader;
 import com.programmers.bucketback.error.BusinessException;
 import com.programmers.bucketback.error.ErrorCode;
@@ -33,6 +35,7 @@ public class BucketService {
 	private final BucketReader bucketReader;
 	private final MemberReader memberReader;
 	private final ItemReader itemReader;
+	private final MemberItemReader memberItemReader;
 	private final MemberUtils memberUtils;
 
 	/** 버킷 생성 */
@@ -69,19 +72,22 @@ public class BucketService {
 	/**
 	 * 버킷 조회 수정을 위한 멤버 아이템 목록 조회
 	 */
-	public CursorSummary<BucketMemberItemSummary> getMemberItemsForModify(
+	public BucketGetMemberItemServiceResponse getMemberItemsForModify(
 		final Long bucketId,
 		final Hobby hobby,
 		final CursorPageParameters parameters
 	) {
 		Long memberId = memberUtils.getCurrentMemberId();
 
-		return bucketReader.readByMemberItems(
+		int totalMemberItemCount = memberItemReader.countByMemberId(memberId);
+		CursorSummary<BucketMemberItemSummary> cursorSummary = bucketReader.readByMemberItems(
 			bucketId,
 			memberId,
 			hobby,
 			parameters
 		);
+
+		return BucketGetMemberItemServiceResponse.of(cursorSummary, totalMemberItemCount);
 	}
 
 	/**

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/bucket/application/dto/response/BucketGetCursorServiceResponse.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/bucket/application/dto/response/BucketGetCursorServiceResponse.java
@@ -1,0 +1,16 @@
+package com.programmers.bucketback.domains.bucket.application.dto.response;
+
+import com.programmers.bucketback.common.cursor.CursorSummary;
+import com.programmers.bucketback.domains.bucket.model.BucketSummary;
+
+public record BucketGetCursorServiceResponse(
+	CursorSummary<BucketSummary> cursorSummary,
+	int totalBucketCount
+) {
+	public static BucketGetCursorServiceResponse of(
+		final CursorSummary<BucketSummary> cursorSummary,
+		final int totalBucketCount
+	) {
+		return new BucketGetCursorServiceResponse(cursorSummary, totalBucketCount);
+	}
+}

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/bucket/application/dto/response/BucketGetCursorServiceResponse.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/bucket/application/dto/response/BucketGetCursorServiceResponse.java
@@ -7,10 +7,4 @@ public record BucketGetCursorServiceResponse(
 	CursorSummary<BucketSummary> cursorSummary,
 	int totalBucketCount
 ) {
-	public static BucketGetCursorServiceResponse of(
-		final CursorSummary<BucketSummary> cursorSummary,
-		final int totalBucketCount
-	) {
-		return new BucketGetCursorServiceResponse(cursorSummary, totalBucketCount);
-	}
 }

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/bucket/application/dto/response/BucketGetMemberItemServiceResponse.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/bucket/application/dto/response/BucketGetMemberItemServiceResponse.java
@@ -1,0 +1,16 @@
+package com.programmers.bucketback.domains.bucket.application.dto.response;
+
+import com.programmers.bucketback.common.cursor.CursorSummary;
+import com.programmers.bucketback.domains.bucket.model.BucketMemberItemSummary;
+
+public record BucketGetMemberItemServiceResponse(
+	CursorSummary<BucketMemberItemSummary> cursorSummary,
+	int totalMemberItemCount
+) {
+	public static BucketGetMemberItemServiceResponse of(
+		final CursorSummary<BucketMemberItemSummary> cursorSummary,
+		final int totalMemberItemCount
+	) {
+		return new BucketGetMemberItemServiceResponse(cursorSummary, totalMemberItemCount);
+	}
+}

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/bucket/application/dto/response/BucketGetMemberItemServiceResponse.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/bucket/application/dto/response/BucketGetMemberItemServiceResponse.java
@@ -7,10 +7,4 @@ public record BucketGetMemberItemServiceResponse(
 	CursorSummary<BucketMemberItemSummary> cursorSummary,
 	int totalMemberItemCount
 ) {
-	public static BucketGetMemberItemServiceResponse of(
-		final CursorSummary<BucketMemberItemSummary> cursorSummary,
-		final int totalMemberItemCount
-	) {
-		return new BucketGetMemberItemServiceResponse(cursorSummary, totalMemberItemCount);
-	}
 }

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/comment/api/dto/response/CommentGetCursorResponse.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/comment/api/dto/response/CommentGetCursorResponse.java
@@ -2,7 +2,7 @@ package com.programmers.bucketback.domains.comment.api.dto.response;
 
 import java.util.List;
 
-import com.programmers.bucketback.domains.comment.application.dto.response.CommentsGetServiceResponse;
+import com.programmers.bucketback.domains.comment.application.dto.response.CommentGetCursorServiceResponse;
 import com.programmers.bucketback.domains.comment.repository.CommentSummary;
 
 public record CommentGetCursorResponse(
@@ -12,13 +12,13 @@ public record CommentGetCursorResponse(
 	List<CommentSummary> comments
 ) {
 	public static CommentGetCursorResponse from(
-		final CommentsGetServiceResponse response
+		final CommentGetCursorServiceResponse response
 	) {
 		return new CommentGetCursorResponse(
-			response.commentSummaries().nextCursorId(),
-			response.commentSummaries().summaryCount(),
+			response.commentSummary().nextCursorId(),
+			response.commentSummary().summaryCount(),
 			response.totalCommentCount(),
-			response.commentSummaries().summaries()
+			response.commentSummary().summaries()
 		);
 	}
 }

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/comment/api/dto/response/CommentGetCursorResponse.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/comment/api/dto/response/CommentGetCursorResponse.java
@@ -2,19 +2,23 @@ package com.programmers.bucketback.domains.comment.api.dto.response;
 
 import java.util.List;
 
-import com.programmers.bucketback.common.cursor.CursorSummary;
+import com.programmers.bucketback.domains.comment.application.dto.response.CommentsGetServiceResponse;
 import com.programmers.bucketback.domains.comment.repository.CommentSummary;
 
 public record CommentGetCursorResponse(
 	String nextCursorId,
 	int totalCount,
+	int totalCommentCount,
 	List<CommentSummary> comments
 ) {
-	public static CommentGetCursorResponse from(final CursorSummary<CommentSummary> summary) {
+	public static CommentGetCursorResponse from(
+		final CommentsGetServiceResponse response
+	) {
 		return new CommentGetCursorResponse(
-			summary.nextCursorId(),
-			summary.summaryCount(),
-			summary.summaries()
+			response.commentSummaries().nextCursorId(),
+			response.commentSummaries().summaryCount(),
+			response.totalCommentCount(),
+			response.commentSummaries().summaries()
 		);
 	}
 }

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/comment/application/CommentService.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/comment/application/CommentService.java
@@ -4,7 +4,7 @@ import org.springframework.stereotype.Service;
 
 import com.programmers.bucketback.common.cursor.CursorPageParameters;
 import com.programmers.bucketback.common.cursor.CursorSummary;
-import com.programmers.bucketback.domains.comment.application.dto.response.CommentsGetServiceResponse;
+import com.programmers.bucketback.domains.comment.application.dto.response.CommentGetCursorServiceResponse;
 import com.programmers.bucketback.domains.comment.domain.Comment;
 import com.programmers.bucketback.domains.comment.implementation.CommentAppender;
 import com.programmers.bucketback.domains.comment.implementation.CommentModifier;
@@ -64,21 +64,20 @@ public class CommentService {
 		commentRemover.remove(commentId);
 	}
 
-	public CommentsGetServiceResponse getFeedComments(
+	public CommentGetCursorServiceResponse getFeedComments(
 		final Long feedId,
 		final CursorPageParameters parameters
 	) {
 		final Long memberId = memberUtils.getCurrentMemberId();
 
 		int totalCommentCount = commentReader.countComments(feedId);
-
 		CursorSummary<CommentSummary> cursorSummary = commentReader.readByCursor(
 			feedId,
 			memberId,
 			parameters
 		);
 
-		return CommentsGetServiceResponse.of(cursorSummary, totalCommentCount);
+		return CommentGetCursorServiceResponse.of(cursorSummary, totalCommentCount);
 	}
 
 	@PayPoint(20)

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/comment/application/CommentService.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/comment/application/CommentService.java
@@ -77,7 +77,7 @@ public class CommentService {
 			parameters
 		);
 
-		return CommentGetCursorServiceResponse.of(cursorSummary, totalCommentCount);
+		return new CommentGetCursorServiceResponse(cursorSummary, totalCommentCount);
 	}
 
 	@PayPoint(20)

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/comment/application/CommentService.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/comment/application/CommentService.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service;
 
 import com.programmers.bucketback.common.cursor.CursorPageParameters;
 import com.programmers.bucketback.common.cursor.CursorSummary;
+import com.programmers.bucketback.domains.comment.application.dto.response.CommentsGetServiceResponse;
 import com.programmers.bucketback.domains.comment.domain.Comment;
 import com.programmers.bucketback.domains.comment.implementation.CommentAppender;
 import com.programmers.bucketback.domains.comment.implementation.CommentModifier;
@@ -63,13 +64,21 @@ public class CommentService {
 		commentRemover.remove(commentId);
 	}
 
-	public CursorSummary<CommentSummary> getFeedComments(
+	public CommentsGetServiceResponse getFeedComments(
 		final Long feedId,
 		final CursorPageParameters parameters
 	) {
 		final Long memberId = memberUtils.getCurrentMemberId();
 
-		return commentReader.readByCursor(feedId, memberId, parameters);
+		int totalCommentCount = commentReader.countComments(feedId);
+
+		CursorSummary<CommentSummary> cursorSummary = commentReader.readByCursor(
+			feedId,
+			memberId,
+			parameters
+		);
+
+		return CommentsGetServiceResponse.of(cursorSummary, totalCommentCount);
 	}
 
 	@PayPoint(20)

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/comment/application/dto/response/CommentGetCursorServiceResponse.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/comment/application/dto/response/CommentGetCursorServiceResponse.java
@@ -3,14 +3,14 @@ package com.programmers.bucketback.domains.comment.application.dto.response;
 import com.programmers.bucketback.common.cursor.CursorSummary;
 import com.programmers.bucketback.domains.comment.repository.CommentSummary;
 
-public record CommentsGetServiceResponse(
-	CursorSummary<CommentSummary> commentSummaries,
+public record CommentGetCursorServiceResponse(
+	CursorSummary<CommentSummary> commentSummary,
 	int totalCommentCount
 ) {
-	public static CommentsGetServiceResponse of(
-		final CursorSummary<CommentSummary> commentSummaries,
+	public static CommentGetCursorServiceResponse of(
+		final CursorSummary<CommentSummary> commentSummary,
 		final int totalCommentCount
 	) {
-		return new CommentsGetServiceResponse(commentSummaries, totalCommentCount);
+		return new CommentGetCursorServiceResponse(commentSummary, totalCommentCount);
 	}
 }

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/comment/application/dto/response/CommentGetCursorServiceResponse.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/comment/application/dto/response/CommentGetCursorServiceResponse.java
@@ -7,10 +7,4 @@ public record CommentGetCursorServiceResponse(
 	CursorSummary<CommentSummary> commentSummary,
 	int totalCommentCount
 ) {
-	public static CommentGetCursorServiceResponse of(
-		final CursorSummary<CommentSummary> commentSummary,
-		final int totalCommentCount
-	) {
-		return new CommentGetCursorServiceResponse(commentSummary, totalCommentCount);
-	}
 }

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/comment/application/dto/response/CommentsGetServiceResponse.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/comment/application/dto/response/CommentsGetServiceResponse.java
@@ -1,0 +1,16 @@
+package com.programmers.bucketback.domains.comment.application.dto.response;
+
+import com.programmers.bucketback.common.cursor.CursorSummary;
+import com.programmers.bucketback.domains.comment.repository.CommentSummary;
+
+public record CommentsGetServiceResponse(
+	CursorSummary<CommentSummary> commentSummaries,
+	int totalCommentCount
+) {
+	public static CommentsGetServiceResponse of(
+		final CursorSummary<CommentSummary> commentSummaries,
+		final int totalCommentCount
+	) {
+		return new CommentsGetServiceResponse(commentSummaries, totalCommentCount);
+	}
+}

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/item/api/ItemController.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/item/api/ItemController.java
@@ -28,8 +28,8 @@ import com.programmers.bucketback.domains.item.application.ItemService;
 import com.programmers.bucketback.domains.item.application.dto.ItemAddServiceResponse;
 import com.programmers.bucketback.domains.item.application.dto.ItemGetNamesServiceResponse;
 import com.programmers.bucketback.domains.item.application.dto.ItemGetServiceResponse;
+import com.programmers.bucketback.domains.item.application.dto.MemberItemGetServiceResponse;
 import com.programmers.bucketback.domains.item.model.ItemCursorSummary;
-import com.programmers.bucketback.domains.item.model.MemberItemSummary;
 import com.programmers.bucketback.global.cursor.CursorRequest;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -115,11 +115,11 @@ public class ItemController {
 		@ModelAttribute("request") @Valid final CursorRequest request
 	) {
 		Hobby hobby = Hobby.fromName(hobbyName);
-		CursorSummary<MemberItemSummary> cursorSummary = itemService.getMemberItemsByCursor(
+		MemberItemGetServiceResponse serviceResponse = itemService.getMemberItemsByCursor(
 			hobby,
 			request.toParameters()
 		);
-		MemberItemGetByCursorResponse response = MemberItemGetByCursorResponse.from(cursorSummary);
+		MemberItemGetByCursorResponse response = MemberItemGetByCursorResponse.from(serviceResponse);
 
 		return ResponseEntity.ok(response);
 	}

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/item/api/dto/response/MemberItemGetByCursorResponse.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/item/api/dto/response/MemberItemGetByCursorResponse.java
@@ -2,19 +2,21 @@ package com.programmers.bucketback.domains.item.api.dto.response;
 
 import java.util.List;
 
-import com.programmers.bucketback.common.cursor.CursorSummary;
+import com.programmers.bucketback.domains.item.application.dto.MemberItemGetServiceResponse;
 import com.programmers.bucketback.domains.item.model.MemberItemSummary;
 
 public record MemberItemGetByCursorResponse(
 	String nextCursorId,
 	int totalCount,
+	int totalMemberItemCount,
 	List<MemberItemSummary> summaries
 ) {
-	public static MemberItemGetByCursorResponse from(final CursorSummary<MemberItemSummary> summary) {
+	public static MemberItemGetByCursorResponse from(final MemberItemGetServiceResponse response) {
 		return new MemberItemGetByCursorResponse(
-			summary.nextCursorId(),
-			summary.summaryCount(),
-			summary.summaries()
+			response.cursorSummary().nextCursorId(),
+			response.cursorSummary().summaryCount(),
+			response.totalMemberItemCount(),
+			response.cursorSummary().summaries()
 		);
 	}
 }

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/item/application/ItemService.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/item/application/ItemService.java
@@ -12,6 +12,7 @@ import com.programmers.bucketback.common.model.ItemRemovalList;
 import com.programmers.bucketback.domains.item.application.dto.ItemAddServiceResponse;
 import com.programmers.bucketback.domains.item.application.dto.ItemGetNamesServiceResponse;
 import com.programmers.bucketback.domains.item.application.dto.ItemGetServiceResponse;
+import com.programmers.bucketback.domains.item.application.dto.MemberItemGetServiceResponse;
 import com.programmers.bucketback.domains.item.domain.Item;
 import com.programmers.bucketback.domains.item.domain.MemberItem;
 import com.programmers.bucketback.domains.item.implementation.ItemCursorReader;
@@ -105,17 +106,20 @@ public class ItemService {
 		);
 	}
 
-	public CursorSummary<MemberItemSummary> getMemberItemsByCursor(
+	public MemberItemGetServiceResponse getMemberItemsByCursor(
 		final Hobby hobby,
 		final CursorPageParameters parameters
 	) {
 		Long memberId = memberUtils.getCurrentMemberId();
+		int totalMemberItemCount = memberItemReader.countByMemberIdAndHobby(memberId, hobby);
 
-		return memberItemReader.readMemberItem(
+		CursorSummary<MemberItemSummary> cursorSummary = memberItemReader.readMemberItem(
 			hobby,
 			memberId,
 			parameters
 		);
+
+		return new MemberItemGetServiceResponse(cursorSummary, totalMemberItemCount);
 	}
 
 	public List<ItemRankingServiceResponse> getRanking() {

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/item/application/dto/MemberItemGetServiceResponse.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/item/application/dto/MemberItemGetServiceResponse.java
@@ -1,0 +1,16 @@
+package com.programmers.bucketback.domains.item.application.dto;
+
+import com.programmers.bucketback.common.cursor.CursorSummary;
+import com.programmers.bucketback.domains.item.model.MemberItemSummary;
+
+public record MemberItemGetServiceResponse(
+	CursorSummary<MemberItemSummary> cursorSummary,
+	int totalMemberItemCount
+) {
+	public static MemberItemGetServiceResponse of(
+		final CursorSummary<MemberItemSummary> cursorSummary,
+		final int totalMemberItemCount
+	) {
+		return new MemberItemGetServiceResponse(cursorSummary, totalMemberItemCount);
+	}
+}

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/item/application/dto/MemberItemGetServiceResponse.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/item/application/dto/MemberItemGetServiceResponse.java
@@ -7,10 +7,4 @@ public record MemberItemGetServiceResponse(
 	CursorSummary<MemberItemSummary> cursorSummary,
 	int totalMemberItemCount
 ) {
-	public static MemberItemGetServiceResponse of(
-		final CursorSummary<MemberItemSummary> cursorSummary,
-		final int totalMemberItemCount
-	) {
-		return new MemberItemGetServiceResponse(cursorSummary, totalMemberItemCount);
-	}
 }

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/domains/bucket/implementation/BucketReader.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/domains/bucket/implementation/BucketReader.java
@@ -176,4 +176,8 @@ public class BucketReader {
 		int pageSize = parameters.size() == null ? DEFAULT_PAGING_SIZE : parameters.size();
 		return pageSize;
 	}
+
+	public int countByMemberId(final Long memberId) {
+		return bucketRepository.countByMemberId(memberId);
+	}
 }

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/domains/bucket/repository/BucketRepository.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/domains/bucket/repository/BucketRepository.java
@@ -14,4 +14,6 @@ public interface BucketRepository extends JpaRepository<Bucket, Long>, BucketRep
 	);
 
 	List<Bucket> findAllByMemberId(final Long memberId);
+
+	int countByMemberId(final Long memberId);
 }

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/domains/comment/implementation/CommentReader.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/domains/comment/implementation/CommentReader.java
@@ -46,8 +46,13 @@ public class CommentReader {
 		return CursorUtils.getCursorSummaries(summaries);
 	}
 
+	public int countComments(final Long feedId) {
+		return commentRepository.countByFeedId(feedId);
+	}
+
 	private int getPageSize(final CursorPageParameters parameters) {
 		int pageSize = parameters.size() == null ? DEFAULT_PAGING_SIZE : parameters.size();
 		return pageSize;
 	}
+
 }

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/domains/comment/repository/CommentRepository.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/domains/comment/repository/CommentRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.programmers.bucketback.domains.comment.domain.Comment;
 
 public interface CommentRepository extends JpaRepository<Comment, Long>, CommentRepositoryForCursor {
+	int countByFeedId(final Long feedId);
 }

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/domains/item/implementation/MemberItemReader.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/domains/item/implementation/MemberItemReader.java
@@ -94,4 +94,14 @@ public class MemberItemReader {
 	public int countByMemberId(final Long memberId) {
 		return memberItemRepository.countByMemberId(memberId);
 	}
+
+	public int countByMemberIdAndHobby(
+		final Long memberId,
+		final Hobby hobby
+	) {
+		if (hobby == null) {
+			return memberItemRepository.countByMemberId(memberId);
+		}
+		return memberItemRepository.countByHobbyAndMemberId(hobby, memberId);
+	}
 }

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/domains/item/implementation/MemberItemReader.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/domains/item/implementation/MemberItemReader.java
@@ -91,10 +91,6 @@ public class MemberItemReader {
 		return parameterSize;
 	}
 
-	public int countByMemberId(final Long memberId) {
-		return memberItemRepository.countByMemberId(memberId);
-	}
-
 	public int countByMemberIdAndHobby(
 		final Long memberId,
 		final Hobby hobby

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/domains/item/implementation/MemberItemReader.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/domains/item/implementation/MemberItemReader.java
@@ -90,4 +90,8 @@ public class MemberItemReader {
 
 		return parameterSize;
 	}
+
+	public int countByMemberId(final Long memberId) {
+		return memberItemRepository.countByMemberId(memberId);
+	}
 }

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/domains/item/repository/MemberItemRepository.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/domains/item/repository/MemberItemRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import com.programmers.bucketback.common.model.Hobby;
 import com.programmers.bucketback.domains.item.domain.Item;
 import com.programmers.bucketback.domains.item.domain.MemberItem;
 
@@ -33,4 +34,17 @@ public interface MemberItemRepository extends JpaRepository<MemberItem, Long>, M
 	boolean existsByMemberIdAndItemsIn(@Param("memberId") Long memberId, @Param("items") List<Item> items);
 
 	int countByMemberId(final Long memberId);
+
+	@Query(
+		"""
+				SELECT COUNT(mi)
+			  	FROM MemberItem mi
+			  	JOIN mi.item i
+			  	WHERE i.hobby = :hobby AND mi.memberId = :memberId
+			"""
+	)
+	int countByHobbyAndMemberId(
+		final Hobby hobby,
+		final Long memberId
+	);
 }

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/domains/item/repository/MemberItemRepository.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/domains/item/repository/MemberItemRepository.java
@@ -31,4 +31,6 @@ public interface MemberItemRepository extends JpaRepository<MemberItem, Long>, M
 			"""
 	)
 	boolean existsByMemberIdAndItemsIn(@Param("memberId") Long memberId, @Param("items") List<Item> items);
+
+	int countByMemberId(final Long memberId);
 }


### PR DESCRIPTION
## 📌 PR 종류

어떤 종류의 PR인지 아래 항목 중에 체크 해주세요.
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [ ]  🐛 버그 수정
- [ ]  ✨ 기능 추가
- [ ]  **✅** 테스트 추가
- [ ]  🎨 코드 스타일 변경 (formatting, local variables)
- [x]  🔨 리팩토링 (기능 변경 X)
- [ ]  **💚** 빌드 관련 수정
- [ ]  **📝** 문서 내용 수정
- [ ]  그 외, 어떤 종류인지 기입 바람:
<br>

## 📌 어떤 기능이 추가 되었나요?

<!--어떤 기능이 추가 되었는지 설명해주시고 관련된 지라 이슈 넘버를 추가 해주세요 -->

### Issue Number

no-jira

### 기능 설명

각 커서 조회 api에 총 개수를 count할 수 있는 반환값을 추가함

1. 피드 댓글 목록 조회
2. 버킷 목록 조회
3. 버킷 목록 조회와 수정을 위한 내가 담은 아이템 목록 조회
4. 내가 담은 아이템을 취미별로 조회

<br>

## 📌 기존에 있던 기능에 영향을 주나요?

- [x]  네
- [ ]  아니요

<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->
