### PR TITLE
[OMCT-409] 최대 투표자 수를 제한하는 요구사항 추가

### DIFF
--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/vote/api/dto/request/VoteCreateRequest.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/vote/api/dto/request/VoteCreateRequest.java
@@ -23,7 +23,10 @@ public record VoteCreateRequest(
 
 	@Schema(description = "아이템2 ID", example = "2")
 	@NotNull(message = "아이템2 ID는 필수 값입니다.")
-	Long item2Id
+	Long item2Id,
+
+	@Schema(description = "최대 투표자 수", example = "100")
+	Integer maximumParticipants
 ) {
 	public VoteCreateServiceRequest toCreateVoteServiceRequest() {
 		return VoteCreateServiceRequest.builder()
@@ -31,6 +34,7 @@ public record VoteCreateRequest(
 			.content(content)
 			.item1Id(item1Id)
 			.item2Id(item2Id)
+			.maximumParticipants(maximumParticipants)
 			.build();
 	}
 }

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/vote/application/dto/request/VoteCreateServiceRequest.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/vote/application/dto/request/VoteCreateServiceRequest.java
@@ -10,9 +10,10 @@ public record VoteCreateServiceRequest(
 	Hobby hobby,
 	String content,
 	Long item1Id,
-	Long item2Id
+	Long item2Id,
+	Integer maximumParticipants
 ) {
 	public VoteCreateImplRequest toImplRequest() {
-		return new VoteCreateImplRequest(hobby, content, item1Id, item2Id);
+		return new VoteCreateImplRequest(hobby, content, item1Id, item2Id, maximumParticipants);
 	}
 }

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/domains/vote/domain/Vote.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/domains/vote/domain/Vote.java
@@ -111,6 +111,6 @@ public class Vote extends BaseEntity {
 	}
 
 	public boolean reachMaximumParticipants() {
-		return this.voters.size() == this.maximumParticipants;
+		return this.maximumParticipants != null && this.maximumParticipants == this.voters.size();
 	}
 }

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/domains/vote/domain/Vote.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/domains/vote/domain/Vote.java
@@ -58,6 +58,9 @@ public class Vote extends BaseEntity {
 	@Column(name = "end_time", nullable = false)
 	private LocalDateTime endTime;
 
+	@Column(name = "maximum_participants")
+	private Integer maximumParticipants;
+
 	@OneToMany(mappedBy = "vote", cascade = CascadeType.ALL)
 	private List<Voter> voters = new ArrayList<>();
 
@@ -67,7 +70,8 @@ public class Vote extends BaseEntity {
 		final Long item1Id,
 		final Long item2Id,
 		final Hobby hobby,
-		final String content
+		final String content,
+		final Integer maximumParticipants
 	) {
 		this.memberId = Objects.requireNonNull(memberId);
 		this.item1Id = Objects.requireNonNull(item1Id);
@@ -76,6 +80,7 @@ public class Vote extends BaseEntity {
 		this.content = new Content(content);
 		this.startTime = LocalDateTime.now();
 		this.endTime = startTime.plusDays(1);
+		this.maximumParticipants = maximumParticipants;
 	}
 
 	public String getContent() {
@@ -99,5 +104,13 @@ public class Vote extends BaseEntity {
 	public boolean isVoting() {
 		final LocalDateTime now = LocalDateTime.now();
 		return this.endTime.isAfter(now);
+	}
+
+	public void close(final LocalDateTime now) {
+		this.endTime = now;
+	}
+
+	public boolean reachMaximumParticipants() {
+		return this.voters.size() == this.maximumParticipants;
 	}
 }

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/domains/vote/implementation/VoteAppender.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/domains/vote/implementation/VoteAppender.java
@@ -26,6 +26,7 @@ public class VoteAppender {
 			.item2Id(request.item2Id())
 			.hobby(request.hobby())
 			.content(request.content())
+			.maximumParticipants(request.maximumParticipants())
 			.build();
 
 		return voteRepository.save(vote);

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/domains/vote/implementation/VoteManager.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/domains/vote/implementation/VoteManager.java
@@ -1,5 +1,7 @@
 package com.programmers.bucketback.domains.vote.implementation;
 
+import java.time.LocalDateTime;
+
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,6 +27,10 @@ public class VoteManager {
 		final Voter voter = voterReader.read(vote, memberId, itemId);
 
 		voter.participate(itemId);
+
+		if (vote.reachMaximumParticipants()) {
+			vote.close(LocalDateTime.now());
+		}
 	}
 
 	@Transactional

--- a/bucketback-domain/src/main/java/com/programmers/bucketback/domains/vote/model/VoteCreateImplRequest.java
+++ b/bucketback-domain/src/main/java/com/programmers/bucketback/domains/vote/model/VoteCreateImplRequest.java
@@ -9,6 +9,7 @@ public record VoteCreateImplRequest(
 	Hobby hobby,
 	String content,
 	Long item1Id,
-	Long item2Id
+	Long item2Id,
+	Integer maximumParticipants
 ) {
 }


### PR DESCRIPTION
## 📌 PR 종류

어떤 종류의 PR인지 아래 항목 중에 체크 해주세요.
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [ ]  🐛 버그 수정
- [x]  ✨ 기능 추가
- [ ]  **✅** 테스트 추가
- [ ]  🎨 코드 스타일 변경 (formatting, local variables)
- [ ]  🔨 리팩토링 (기능 변경 X)
- [ ]  **💚** 빌드 관련 수정
- [ ]  **📝** 문서 내용 수정
- [ ]  그 외, 어떤 종류인지 기입 바람:
<br>

## 📌 어떤 기능이 추가 되었나요?

<!--어떤 기능이 추가 되었는지 설명해주시고 관련된 지라 이슈 넘버를 추가 해주세요 -->

### Issue Number

OMCT-409

### 기능 설명

**기존 투표**
```
- 투표는 생성된 일시부터 24시간동안 열린다.
- 투표자 수에 제한이 없다.
```

**추가된 요구사항**
```
- 투표를 생성할 때 최대 투표자 수를 정할 수 있다. (option)
- 지정한 투표자 수가 되면 투표는 그 즉시 종료된다.
````

**보충해야 할 부분**
- 투표 랭킹에서 24시간 이내 종료된 투표 삭제하기
- 투표 첫 참여와 재참여 API 분리하기

💡 일단 프론트와 합의한 요구사항 먼저 추가하고 이때 발생한 동시성 문제는 추후에 해결하기로 했습니다.

<br>

## 📌 기존에 있던 기능에 영향을 주나요?

- [ ]  네
- [x]  아니요

<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->
