### PR TITLE
[OMCT-411] 로그인 연장 기능 추가 - Refresh token으로 Access token 재발급

### DIFF
--- a/bucketback-api/build.gradle
+++ b/bucketback-api/build.gradle
@@ -33,6 +33,10 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    // Cache
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation "com.github.ben-manes.caffeine:caffeine:3.1.8"
 }
 
 jar {

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/member/api/MemberController.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/member/api/MemberController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -25,6 +26,7 @@ import com.programmers.bucketback.domains.member.api.dto.request.MemberLoginRequ
 import com.programmers.bucketback.domains.member.api.dto.request.MemberSignupRequest;
 import com.programmers.bucketback.domains.member.api.dto.request.MemberUpdatePasswordRequest;
 import com.programmers.bucketback.domains.member.api.dto.request.MemberUpdateProfileRequest;
+import com.programmers.bucketback.domains.member.api.dto.response.AccessTokenResponse;
 import com.programmers.bucketback.domains.member.api.dto.response.MemberCheckEmailResponse;
 import com.programmers.bucketback.domains.member.api.dto.response.MemberCheckJwtResponse;
 import com.programmers.bucketback.domains.member.api.dto.response.MemberCheckNicknameResponse;
@@ -85,6 +87,18 @@ public class MemberController {
 			.path("/")
 			.build();
 		httpServletResponse.addHeader(SET_COOKIE, cookie.toString());
+
+		return ResponseEntity.ok(response);
+	}
+
+	@Operation(summary = "로그인 연장", description = "Refresh Token 을 이용하여 Access Token 을 재발급 받습니다.")
+	@PostMapping("/refresh")
+	public ResponseEntity<AccessTokenResponse> extendLogin(
+		@CookieValue("refresh-token") final String refreshToken,
+		@RequestHeader("Authorization") final String authorizationHeader
+	) {
+		final String accessToken = memberService.extendLogin(refreshToken, authorizationHeader);
+		final AccessTokenResponse response = new AccessTokenResponse(accessToken);
 
 		return ResponseEntity.ok(response);
 	}

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/member/api/MemberController.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/member/api/MemberController.java
@@ -6,6 +6,8 @@ import java.io.IOException;
 
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -85,6 +87,22 @@ public class MemberController {
 		httpServletResponse.addHeader(SET_COOKIE, cookie.toString());
 
 		return ResponseEntity.ok(response);
+	}
+
+	@Operation(summary = "로그아웃")
+	@DeleteMapping("/logout")
+	public ResponseEntity<Void> logout(@CookieValue("refresh-token") final String refreshToken) {
+		memberService.logout(refreshToken);
+
+		return ResponseEntity.ok().build();
+	}
+
+	@Operation(summary = "회원 탈퇴")
+	@DeleteMapping("/delete")
+	public ResponseEntity<Void> deleteMember(@CookieValue("refresh-token") final String refreshToken) {
+		memberService.deleteMember(refreshToken);
+
+		return ResponseEntity.ok().build();
 	}
 
 	@Operation(summary = "프로필 수정", description = "MemberUpdateProfileRequest 을 이용하여 프로필을 수정합니다.")

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/member/api/dto/response/AccessTokenResponse.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/member/api/dto/response/AccessTokenResponse.java
@@ -1,0 +1,6 @@
+package com.programmers.bucketback.domains.member.api.dto.response;
+
+public record AccessTokenResponse(
+	String accessToken
+) {
+}

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/member/api/dto/response/MemberLoginResponse.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/member/api/dto/response/MemberLoginResponse.java
@@ -5,15 +5,13 @@ import com.programmers.bucketback.domains.member.application.dto.response.Member
 public record MemberLoginResponse(
         Long memberId,
 		String nickname,
-		String accessToken,
-		String refreshToken
+		String accessToken
 ) {
 	public static MemberLoginResponse from(final MemberLoginServiceResponse serviceResponse) {
 		return new MemberLoginResponse(
 			serviceResponse.memberId(),
 			serviceResponse.nickname(),
-			serviceResponse.accessToken(),
-			serviceResponse.refreshToken()
+			serviceResponse.accessToken()
 		);
 	}
 }

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/member/api/dto/response/MemberLoginResponse.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/member/api/dto/response/MemberLoginResponse.java
@@ -5,13 +5,15 @@ import com.programmers.bucketback.domains.member.application.dto.response.Member
 public record MemberLoginResponse(
         Long memberId,
 		String nickname,
-        String jwtToken
+		String accessToken,
+		String refreshToken
 ) {
 	public static MemberLoginResponse from(final MemberLoginServiceResponse serviceResponse) {
 		return new MemberLoginResponse(
 			serviceResponse.memberId(),
 			serviceResponse.nickname(),
-			serviceResponse.jwtToken()
+			serviceResponse.accessToken(),
+			serviceResponse.refreshToken()
 		);
 	}
 }

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/member/application/MemberSecurityManager.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/member/application/MemberSecurityManager.java
@@ -46,4 +46,8 @@ public class MemberSecurityManager {
 		Member.validatePassword(password);
 		return passwordEncoder.encode(password);
 	}
+
+	public void removeRefreshToken(final String refreshToken) {
+		securityManager.removeRefreshToken(refreshToken);
+	}
 }

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/member/application/MemberSecurityManager.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/member/application/MemberSecurityManager.java
@@ -36,7 +36,7 @@ public class MemberSecurityManager {
 		final String nickname = member.getNickname();
 
 		securityManager.authenticate(memberId, rawPassword);
-		final String jwtToken = securityManager.generateToken(member);
+		final String jwtToken = securityManager.generateAccessToken(memberId);
 
 		return new MemberLoginServiceResponse(memberId, nickname, jwtToken);
 	}

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/member/application/MemberSecurityManager.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/member/application/MemberSecurityManager.java
@@ -50,4 +50,11 @@ public class MemberSecurityManager {
 	public void removeRefreshToken(final String refreshToken) {
 		securityManager.removeRefreshToken(refreshToken);
 	}
+
+	public String reissueAccessToken(
+		final String refreshToken,
+		final String authorizationHeader
+	) {
+		return securityManager.reissueAccessToken(refreshToken, authorizationHeader);
+	}
 }

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/member/application/MemberSecurityManager.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/member/application/MemberSecurityManager.java
@@ -36,9 +36,10 @@ public class MemberSecurityManager {
 		final String nickname = member.getNickname();
 
 		securityManager.authenticate(memberId, rawPassword);
-		final String jwtToken = securityManager.generateAccessToken(memberId);
+		final String accessToken = securityManager.generateAccessToken(memberId);
+		final String refreshToken = securityManager.generateRefreshToken(memberId);
 
-		return new MemberLoginServiceResponse(memberId, nickname, jwtToken);
+		return new MemberLoginServiceResponse(memberId, nickname, accessToken, refreshToken);
 	}
 
 	public String encodePassword(final String password) {

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/member/application/MemberService.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/member/application/MemberService.java
@@ -69,7 +69,10 @@ public class MemberService {
 		return memberSecurityManager.login(rawPassword, member);
 	}
 
-	public String extendLogin(final String refreshToken, final String authorizationHeader) {
+	public String extendLogin(
+		final String refreshToken,
+		final String authorizationHeader
+	) {
 		return memberSecurityManager.reissueAccessToken(refreshToken, authorizationHeader);
 	}
 

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/member/application/MemberService.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/member/application/MemberService.java
@@ -69,10 +69,14 @@ public class MemberService {
 		return memberSecurityManager.login(rawPassword, member);
 	}
 
-	public void deleteMember() {
-		final Member member = memberUtils.getCurrentMember();
+	public void logout(final String refreshToken) {
+		memberSecurityManager.removeRefreshToken(refreshToken);
+	}
 
+	public void deleteMember(final String refreshToken) {
+		final Member member = memberUtils.getCurrentMember();
 		memberRemover.remove(member);
+		memberSecurityManager.removeRefreshToken(refreshToken);
 	}
 
 	public void updateProfile(

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/member/application/MemberService.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/member/application/MemberService.java
@@ -69,6 +69,10 @@ public class MemberService {
 		return memberSecurityManager.login(rawPassword, member);
 	}
 
+	public String extendLogin(final String refreshToken, final String authorizationHeader) {
+		return memberSecurityManager.reissueAccessToken(refreshToken, authorizationHeader);
+	}
+
 	public void logout(final String refreshToken) {
 		memberSecurityManager.removeRefreshToken(refreshToken);
 	}

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/member/application/dto/response/MemberLoginServiceResponse.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/member/application/dto/response/MemberLoginServiceResponse.java
@@ -3,6 +3,7 @@ package com.programmers.bucketback.domains.member.application.dto.response;
 public record MemberLoginServiceResponse(
 	Long memberId,
 	String nickname,
-	String jwtToken
+	String accessToken,
+	String refreshToken
 ) {
 }

--- a/bucketback-api/src/main/java/com/programmers/bucketback/global/cache/CacheConfiguration.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/global/cache/CacheConfiguration.java
@@ -1,0 +1,33 @@
+package com.programmers.bucketback.global.cache;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.cache.support.SimpleCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+@EnableCaching
+@Configuration
+public class CacheConfiguration {
+	@Bean
+	public CacheManager cacheManager() {
+		final List<CaffeineCache> caffeineCaches = Arrays.stream(CacheType.values())
+			.map(cache -> new CaffeineCache(cache.getCacheName(), Caffeine.newBuilder().recordStats()
+				.expireAfterWrite(cache.getExpireAfterWrite(), TimeUnit.HOURS)
+				.maximumSize(cache.getEntryMaxSize())
+				.build()))
+			.toList();
+
+		final SimpleCacheManager cacheManager = new SimpleCacheManager();
+		cacheManager.setCaches(caffeineCaches);
+
+		return cacheManager;
+	}
+}

--- a/bucketback-api/src/main/java/com/programmers/bucketback/global/cache/CacheConfiguration.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/global/cache/CacheConfiguration.java
@@ -20,7 +20,7 @@ public class CacheConfiguration {
 	public CacheManager cacheManager() {
 		final List<CaffeineCache> caffeineCaches = Arrays.stream(CacheType.values())
 			.map(cache -> new CaffeineCache(cache.getCacheName(), Caffeine.newBuilder().recordStats()
-				.expireAfterWrite(cache.getExpireAfterWrite(), TimeUnit.HOURS)
+				.expireAfterWrite(cache.getExpireAfterWrite(), TimeUnit.SECONDS)
 				.maximumSize(cache.getEntryMaxSize())
 				.build()))
 			.toList();

--- a/bucketback-api/src/main/java/com/programmers/bucketback/global/cache/CacheType.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/global/cache/CacheType.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum CacheType {
 
-	REFRESH_TOKEN("refreshToken", 12, 1)
+	REFRESH_TOKEN("refreshToken", 1209600, 10000)
 	;
 
 	private final String cacheName;

--- a/bucketback-api/src/main/java/com/programmers/bucketback/global/cache/CacheType.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/global/cache/CacheType.java
@@ -1,0 +1,16 @@
+package com.programmers.bucketback.global.cache;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CacheType {
+
+	REFRESH_TOKEN("refreshToken", 12, 1)
+	;
+
+	private final String cacheName;
+	private final int expireAfterWrite;
+	private final int entryMaxSize;
+}

--- a/bucketback-api/src/main/java/com/programmers/bucketback/global/config/security/SecurityConfiguration.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/global/config/security/SecurityConfiguration.java
@@ -46,6 +46,7 @@ public class SecurityConfiguration {
 					.requestMatchers("/api/members/check/nickname").permitAll()
 					.requestMatchers("/api/members/check/email").permitAll()
 					.requestMatchers("/api/members/{nickname}").permitAll()
+					.requestMatchers("/api/members/refresh").permitAll()
 
 					.requestMatchers(HttpMethod.GET, "/api/votes").permitAll()
 					.requestMatchers(HttpMethod.GET, "/api/votes/{voteId}").permitAll()

--- a/bucketback-api/src/main/java/com/programmers/bucketback/global/config/security/SecurityManager.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/global/config/security/SecurityManager.java
@@ -1,5 +1,6 @@
 package com.programmers.bucketback.global.config.security;
 
+import org.springframework.cache.CacheManager;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.stereotype.Component;
@@ -12,8 +13,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class SecurityManager {
 
+	public static final String REFRESH_TOKEN_CACHE = "refreshToken";
+
 	private final JwtService jwtService;
 	private final AuthenticationManager authenticationManager;
+	private final CacheManager cacheManager;
 
 	public void authenticate(
 		final Long memberId,
@@ -30,6 +34,9 @@ public class SecurityManager {
 	}
 
 	public String generateRefreshToken(final Long memberId) {
-		return jwtService.generateRefreshToken(memberId.toString());
+		final String refreshToken = jwtService.generateRefreshToken();
+		cacheManager.getCache(REFRESH_TOKEN_CACHE).put(refreshToken, memberId);
+
+		return refreshToken;
 	}
 }

--- a/bucketback-api/src/main/java/com/programmers/bucketback/global/config/security/SecurityManager.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/global/config/security/SecurityManager.java
@@ -4,7 +4,6 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.stereotype.Component;
 
-import com.programmers.bucketback.domains.member.domain.Member;
 import com.programmers.bucketback.global.config.security.jwt.JwtService;
 
 import lombok.RequiredArgsConstructor;
@@ -26,9 +25,7 @@ public class SecurityManager {
 		authenticationManager.authenticate(authenticationToken);
 	}
 
-	public String generateToken(final Member member) {
-		final MemberSecurity memberSecurity = new MemberSecurity(member);
-
-		return jwtService.generateToken(memberSecurity);
+	public String generateAccessToken(final Long memberId) {
+		return jwtService.generateAccessToken(memberId.toString());
 	}
 }

--- a/bucketback-api/src/main/java/com/programmers/bucketback/global/config/security/SecurityManager.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/global/config/security/SecurityManager.java
@@ -51,17 +51,13 @@ public class SecurityManager {
 		if (jwtService.isRefreshValidAndAccessInValid(refreshToken, accessToken)) {
 			final Long memberId = cacheManager.getCache(REFRESH_TOKEN_CACHE).get(refreshToken, Long.class);
 
-			if (memberId == null) {
-				throw new RuntimeException("Refresh Token이 유효하지 않습니다.");
-			}
-
-			return generateAccessToken(Long.valueOf(memberId));
+			return generateAccessToken(memberId);
 		}
 
-		if (jwtService.isRefreshAndAccessValid(refreshToken, accessToken)) {
+		if (jwtService.isAccessTokenValid(accessToken)) {
 			return accessToken;
 		}
 
-		throw new JwtException("Access Token을 재발급 할 수 없습니다.");
+		throw new JwtException("Refresh Token이 유효하지 않습니다.");
 	}
 }

--- a/bucketback-api/src/main/java/com/programmers/bucketback/global/config/security/SecurityManager.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/global/config/security/SecurityManager.java
@@ -39,4 +39,8 @@ public class SecurityManager {
 
 		return refreshToken;
 	}
+
+	public void removeRefreshToken(final String refreshToken) {
+		cacheManager.getCache(REFRESH_TOKEN_CACHE).evict(refreshToken);
+	}
 }

--- a/bucketback-api/src/main/java/com/programmers/bucketback/global/config/security/SecurityManager.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/global/config/security/SecurityManager.java
@@ -28,4 +28,8 @@ public class SecurityManager {
 	public String generateAccessToken(final Long memberId) {
 		return jwtService.generateAccessToken(memberId.toString());
 	}
+
+	public String generateRefreshToken(final Long memberId) {
+		return jwtService.generateRefreshToken(memberId.toString());
+	}
 }

--- a/bucketback-api/src/main/java/com/programmers/bucketback/global/config/security/jwt/JwtAuthenticationFilter.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/global/config/security/jwt/JwtAuthenticationFilter.java
@@ -35,11 +35,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		@NonNull final HttpServletResponse response,
 		@NonNull final FilterChain filterChain
 	) throws ServletException, IOException {
+		final String requestUri = request.getRequestURI();
 		final String authHeader = request.getHeader("Authorization");
 		final String jwt;
 		final String memberId;
 
-		if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+		if (requestUri.equals("/api/members/refresh") || authHeader == null || !authHeader.startsWith("Bearer ")) {
 			filterChain.doFilter(request, response);
 			return;
 		}

--- a/bucketback-api/src/main/java/com/programmers/bucketback/global/config/security/jwt/JwtAuthenticationFilter.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/global/config/security/jwt/JwtAuthenticationFilter.java
@@ -13,8 +13,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.servlet.HandlerExceptionResolver;
 
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.security.SignatureException;
+import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -48,9 +47,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		jwt = authHeader.substring(7);
 
 		try {
-			memberId = jwtService.extractAccessTokenUsername(jwt);
+			if (SecurityContextHolder.getContext().getAuthentication() == null && jwtService.isAccessTokenValid(jwt)) {
+				memberId = jwtService.extractUsername(jwt);
 
-			if (memberId != null && SecurityContextHolder.getContext().getAuthentication() == null && jwtService.isAccessTokenValid(jwt)) {
 				final UserDetails principal = makePrincipal(memberId);
 				final UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
 					principal,
@@ -63,7 +62,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 			filterChain.doFilter(request, response);
 
-		} catch (SignatureException | ExpiredJwtException e) {
+		} catch (JwtException e) {
 			handlerExceptionResolver.resolveException(request, response, null, e);
 		}
 	}

--- a/bucketback-api/src/main/java/com/programmers/bucketback/global/config/security/jwt/JwtAuthenticationFilter.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/global/config/security/jwt/JwtAuthenticationFilter.java
@@ -47,9 +47,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		jwt = authHeader.substring(7);
 
 		try {
-			memberId = jwtService.extractUsername(jwt);
+			memberId = jwtService.extractAccessTokenUsername(jwt);
 
-			if (memberId != null && SecurityContextHolder.getContext().getAuthentication() == null && jwtService.isTokenValid(jwt)) {
+			if (memberId != null && SecurityContextHolder.getContext().getAuthentication() == null && jwtService.isAccessTokenValid(jwt)) {
 				final UserDetails principal = makePrincipal(memberId);
 				final UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
 					principal,

--- a/bucketback-api/src/main/java/com/programmers/bucketback/global/config/security/jwt/JwtAuthenticationFilter.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/global/config/security/jwt/JwtAuthenticationFilter.java
@@ -25,6 +25,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
+	public static final int TOKEN_BEGIN_INDEX = 7;
+
 	private final JwtService jwtService;
 	private final HandlerExceptionResolver handlerExceptionResolver;
 
@@ -44,7 +46,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 			return;
 		}
 
-		jwt = authHeader.substring(7);
+		jwt = authHeader.substring(TOKEN_BEGIN_INDEX);
 
 		try {
 			if (SecurityContextHolder.getContext().getAuthentication() == null && jwtService.isAccessTokenValid(jwt)) {

--- a/bucketback-api/src/main/java/com/programmers/bucketback/global/config/security/jwt/JwtConfig.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/global/config/security/jwt/JwtConfig.java
@@ -4,7 +4,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "jwt")
 public record JwtConfig(
-	String secretKey,
-	long expirationSeconds
+	String accessSecretKey,
+	long accessExpirationSeconds,
+	String refreshSecretKey,
+	long refreshExpirationSeconds
 ) {
 }

--- a/bucketback-api/src/main/java/com/programmers/bucketback/global/config/security/jwt/JwtService.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/global/config/security/jwt/JwtService.java
@@ -2,7 +2,6 @@ package com.programmers.bucketback.global.config.security.jwt;
 
 import java.security.Key;
 import java.util.Date;
-import java.util.function.Function;
 
 import org.springframework.stereotype.Service;
 
@@ -22,16 +21,7 @@ public class JwtService {
 	private final JwtConfig jwtConfig;
 
 	public String extractUsername(final String token) {
-		return extractClaim(token, Claims::getSubject, jwtConfig.accessSecretKey());
-	}
-
-	public <T> T extractClaim(
-		final String token,
-		final Function<Claims, T> claimsTResolver,
-		final String secretKey
-	) {
-		final Claims claims = extractAllClaims(token, secretKey);
-		return claimsTResolver.apply(claims);
+		return extractClaim(token, jwtConfig.accessSecretKey()).getSubject();
 	}
 
 	public String generateAccessToken(final String subject) {
@@ -96,10 +86,10 @@ public class JwtService {
 		final String token,
 		final String secretKey
 	) {
-		return extractClaim(token, Claims::getExpiration, secretKey);
+		return extractClaim(token, secretKey).getExpiration();
 	}
 
-	private Claims extractAllClaims(
+	private Claims extractClaim(
 		final String token,
 		final String secretKey
 	) {

--- a/bucketback-api/src/main/java/com/programmers/bucketback/global/config/security/jwt/JwtService.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/global/config/security/jwt/JwtService.java
@@ -55,9 +55,8 @@ public class JwtService {
 			.compact();
 	}
 
-	public String generateRefreshToken(final String subject) {
+	public String generateRefreshToken() {
 		return Jwts.builder()
-			.setSubject(subject)
 			.setIssuedAt(new Date(System.currentTimeMillis()))
 			.setExpiration(new Date(System.currentTimeMillis() + jwtConfig.refreshExpirationSeconds() * 1000L))
 			.signWith(getSignInKey(jwtConfig.refreshSecretKey()), SignatureAlgorithm.HS256)

--- a/bucketback-api/src/main/java/com/programmers/bucketback/global/config/security/jwt/JwtService.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/global/config/security/jwt/JwtService.java
@@ -51,19 +51,15 @@ public class JwtService {
 			.compact();
 	}
 
-	public boolean isTokenValid(
-		final String token,
-		final UserDetails userDetails
-	) {
-		final String username = extractUsername(token);
-		return (username.equals(userDetails.getUsername())) && !isTokenExpired(token);
+	public boolean isTokenValid(final String token) {
+		return !isTokenExpired(token);
 	}
 
 	private boolean isTokenExpired(final String token) {
-		return extractExpiratiob(token).before(new Date());
+		return extractExpiration(token).before(new Date());
 	}
 
-	private Date extractExpiratiob(final String token) {
+	private Date extractExpiration(final String token) {
 		return extractClaim(token, Claims::getExpiration);
 	}
 

--- a/bucketback-api/src/main/java/com/programmers/bucketback/global/config/security/jwt/JwtService.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/global/config/security/jwt/JwtService.java
@@ -21,15 +21,20 @@ public class JwtService {
 
 	private final JwtConfig jwtConfig;
 
-	public String extractUsername(final String token) {
-		return extractClaim(token, Claims::getSubject);
+	public String extractAccessTokenUsername(final String token) {
+		return extractClaim(token, Claims::getSubject, jwtConfig.accessSecretKey());
+	}
+
+	public String extractRefreshTokenUsername(final String token) {
+		return extractClaim(token, Claims::getSubject, jwtConfig.refreshSecretKey());
 	}
 
 	public <T> T extractClaim(
 		final String token,
-		final Function<Claims, T> claimsTResolver
+		final Function<Claims, T> claimsTResolver,
+		final String secretKey
 	) {
-		final Claims claims = extractAllClaims(token);
+		final Claims claims = extractAllClaims(token, secretKey);
 		return claimsTResolver.apply(claims);
 	}
 
@@ -45,34 +50,56 @@ public class JwtService {
 			.setClaims(extraClaims)
 			.setSubject(subject)
 			.setIssuedAt(new Date(System.currentTimeMillis()))
-			.setExpiration(new Date(System.currentTimeMillis() + 1000 * jwtConfig.expirationSeconds()))
-			.signWith(getSignInKey(), SignatureAlgorithm.HS256)
+			.setExpiration(new Date(System.currentTimeMillis() + jwtConfig.accessExpirationSeconds() * 1000L))
+			.signWith(getSignInKey(jwtConfig.accessSecretKey()), SignatureAlgorithm.HS256)
 			.compact();
 	}
 
-	public boolean isTokenValid(final String token) {
-		return !isTokenExpired(token);
+	public String generateRefreshToken(final String subject) {
+		return Jwts.builder()
+			.setSubject(subject)
+			.setIssuedAt(new Date(System.currentTimeMillis()))
+			.setExpiration(new Date(System.currentTimeMillis() + jwtConfig.refreshExpirationSeconds() * 1000L))
+			.signWith(getSignInKey(jwtConfig.refreshSecretKey()), SignatureAlgorithm.HS256)
+			.compact();
 	}
 
-	private boolean isTokenExpired(final String token) {
-		return extractExpiration(token).before(new Date());
+	public boolean isAccessTokenValid(final String token) {
+		return !isTokenExpired(token, jwtConfig.accessSecretKey());
 	}
 
-	private Date extractExpiration(final String token) {
-		return extractClaim(token, Claims::getExpiration);
+	public boolean isRefreshTokenValid(final String token) {
+		return !isTokenExpired(token, jwtConfig.refreshSecretKey());
 	}
 
-	private Claims extractAllClaims(final String token) {
+	private boolean isTokenExpired(
+		final String token,
+		final String secretKey
+	) {
+		return extractExpiration(token, secretKey).before(new Date());
+	}
+
+	private Date extractExpiration(
+		final String token,
+		final String secretKey
+	) {
+		return extractClaim(token, Claims::getExpiration, secretKey);
+	}
+
+	private Claims extractAllClaims(
+		final String token,
+		final String secretKey
+	) {
 		return Jwts
 			.parserBuilder()
-			.setSigningKey(getSignInKey())
+			.setSigningKey(getSignInKey(secretKey))
 			.build()
 			.parseClaimsJws(token)
 			.getBody();
 	}
 
-	private Key getSignInKey() {
-		byte[] keyBytes = Decoders.BASE64.decode(jwtConfig.secretKey());
+	private Key getSignInKey(final String secretKey) {
+		byte[] keyBytes = Decoders.BASE64.decode(secretKey);
 		return Keys.hmacShaKeyFor(keyBytes);
 	}
 }

--- a/bucketback-api/src/main/java/com/programmers/bucketback/global/config/security/jwt/JwtService.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/global/config/security/jwt/JwtService.java
@@ -6,7 +6,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
 import io.jsonwebtoken.Claims;
@@ -34,17 +33,17 @@ public class JwtService {
 		return claimsTResolver.apply(claims);
 	}
 
-	public String generateToken(final UserDetails userDetails) {
-		return generateToken(new HashMap<>(), userDetails);
+	public String generateAccessToken(final String subject) {
+		return generateAccessToken(new HashMap<>(), subject);
 	}
 
-	public String generateToken(
+	public String generateAccessToken(
 		final Map<String, Object> extraClaims,
-		final UserDetails userDetails
+		final String subject
 	) {
 		return Jwts.builder()
 			.setClaims(extraClaims)
-			.setSubject(userDetails.getUsername())
+			.setSubject(subject)
 			.setIssuedAt(new Date(System.currentTimeMillis()))
 			.setExpiration(new Date(System.currentTimeMillis() + 1000 * jwtConfig.expirationSeconds()))
 			.signWith(getSignInKey(), SignatureAlgorithm.HS256)

--- a/bucketback-api/src/main/java/com/programmers/bucketback/global/error/GlobalExceptionHandler.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/global/error/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestCookieException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -15,8 +16,6 @@ import com.programmers.bucketback.error.BusinessException;
 import com.programmers.bucketback.error.EntityNotFoundException;
 import com.programmers.bucketback.error.ErrorCode;
 
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.security.SignatureException;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -63,18 +62,10 @@ public class GlobalExceptionHandler {
 		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
 	}
 
-	@ExceptionHandler(SignatureException.class)
-	protected ResponseEntity<ErrorResponse> handleSignatureException(final SignatureException e) {
-		log.error("SignatureException", e);
-		final ErrorResponse response = ErrorResponse.from(ErrorCode.BAD_SIGNATURE_JWT);
-
-		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
-	}
-
-	@ExceptionHandler(ExpiredJwtException.class)
-	protected ResponseEntity<ErrorResponse> handleJwtException(final ExpiredJwtException e) {
-		log.error("ExpiredJwtException", e);
-		final ErrorResponse response = ErrorResponse.from(ErrorCode.EXPIRED_JWT);
+	@ExceptionHandler(MissingRequestCookieException.class)
+	protected ResponseEntity<ErrorResponse> handleMissingRequestCookieException(final MissingRequestCookieException e) {
+		log.error("MissingRequestCookieException", e);
+		final ErrorResponse response = ErrorResponse.from(ErrorCode.EXPIRED_REFRESH_TOKEN);
 
 		return new ResponseEntity<>(response, HttpStatus.UNAUTHORIZED);
 	}

--- a/bucketback-api/src/main/java/com/programmers/bucketback/global/util/MemberUtils.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/global/util/MemberUtils.java
@@ -4,8 +4,6 @@ import org.springframework.stereotype.Component;
 
 import com.programmers.bucketback.domains.member.domain.Member;
 import com.programmers.bucketback.domains.member.implementation.MemberReader;
-import com.programmers.bucketback.error.BusinessException;
-import com.programmers.bucketback.error.ErrorCode;
 import com.programmers.bucketback.global.config.security.SecurityUtils;
 
 import lombok.RequiredArgsConstructor;
@@ -17,31 +15,12 @@ public final class MemberUtils {
 	private final MemberReader memberReader;
 
 	public Long getCurrentMemberId() {
-		final Long memberId = SecurityUtils.getCurrentMemberId();
-
-		if (memberId == null) {
-			return null;
-		}
-
-		final Member member = memberReader.read(memberId);
-
-		validateMember(member);
-
-		return memberId;
+		return SecurityUtils.getCurrentMemberId();
 	}
 
 	public Member getCurrentMember() {
 		final Long memberId = SecurityUtils.getCurrentMemberId();
-		final Member member = memberReader.read(memberId);
 
-		validateMember(member);
-
-		return member;
-	}
-
-	private void validateMember(final Member member) {
-		if (member.isDeleted()) {
-			throw new BusinessException(ErrorCode.MEMBER_DELETED);
-		}
+		return memberReader.read(memberId);
 	}
 }

--- a/bucketback-common/src/main/java/com/programmers/bucketback/error/ErrorCode.java
+++ b/bucketback-common/src/main/java/com/programmers/bucketback/error/ErrorCode.java
@@ -21,10 +21,12 @@ public enum ErrorCode {
 	UNAUTHORIZED("COMMON_005", "로그인이 필요한 기능입니다."),
 	FORBIDDEN("COMMON_006", "권한이 없습니다."),
 	MISSING_PARAMETER("COMMON_007", "필수 파라미터가 있습니다."),
-	EXPIRED_JWT("COMMON_008", "만료된 JWT 토큰입니다."),
-	BAD_SIGNATURE_JWT("COMMON_009", "잘못된 서명의 JWT 토큰입니다."),
+	EXPIRED_ACCESS_TOKEN("COMMON_008", "Access Token이 만료되었습니다."),
+	INVALID_ACCESS_TOKEN("COMMON_009", "Access Token이 유효하지 않습니다."),
 	IMAGE_MAXIMUM_SIZE_EXCEEDED("COMMON_010", "업로드할 수 있는 파일의 최대 크기를 초과했습니다."),
 	INVALID_REQUEST_FILED_TYPE("COMMON_011", "잘못된 요청 필드 타입입니다."),
+	EXPIRED_REFRESH_TOKEN("COMMON_012", "Refresh Token이 만료되었습니다."),
+	INVALID_REFRESH_TOKEN("COMMON_013", "Refresh Token이 유효하지 않습니다."),
 
 	// Member
 	MEMBER_LOGIN_FAIL("MEMBER_001", "로그인 정보가 잘못 되었습니다."),


### PR DESCRIPTION
## 📌 PR 종류

어떤 종류의 PR인지 아래 항목 중에 체크 해주세요.
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [ ]  🐛 버그 수정
- [x]  ✨ 기능 추가
- [ ]  **✅** 테스트 추가
- [ ]  🎨 코드 스타일 변경 (formatting, local variables)
- [ ]  🔨 리팩토링 (기능 변경 X)
- [ ]  **💚** 빌드 관련 수정
- [ ]  **📝** 문서 내용 수정
- [ ]  그 외, 어떤 종류인지 기입 바람:
<br>

## 📌 어떤 기능이 추가 되었나요?

<!--어떤 기능이 추가 되었는지 설명해주시고 관련된 지라 이슈 넘버를 추가 해주세요 -->

### Issue Number

OMCT-411

### **로그인**
1. 회원이 로그인 정보를 입력하고 로그인을 시도한다.
2. 서버에서는 회원이 입력한 정보와 DB에 저장된 회원 정보를 비교하여 일치하면 로그인 처리를 한다.
3. 로그인 응답값으로는 요청 바디에 회원ID, 닉네임, Access Token이 담겨있고, 쿠키에는 Refresh Token이 담겨있다.

#### **👉 로그인 과정에서 바뀐 부분**
- Access Token과 함께 Refresh Token도 함께 만들어서 요청값에 추가

### **로그아웃 & 회원 탈퇴**
1. 회원이 로그아웃 또는 회원 탈퇴를 시도한다. (로그아웃 API 새로 추가함)
2. 서버에서는 저장해둔 Refresh Token을 삭제한다.

### **Access Token 재발급 과정**
1. 프론트에서 서버로 Access Token은 헤더에, Refresh Token은 쿠키로 보낸다.
2. Refresh Token이 유효하고 Access Token이 유효하지 않다면 새로운 Access Token을 생성해서 반환한다.
3. Refresh Token이 유효하고 Access Token도 유효하면 들어온 Access Token을 요청 바디에 실어 그대로 반환한다.
4. 2번과 3번이 아닌 경우에는 예외를 터뜨린다.

### Refresh Token 스프링 캐시로 저장 (Caffein 캐시)
- 로그인 할 때 캐싱
- 로그아웃 & 회원 탈퇴 시 제거

<br>

## 📌 기존에 있던 기능에 영향을 주나요?

- [ ]  네
- [x]  아니요

<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->
