### PR TITLE
[OMCT-408] 알림 전송 로직 수정

### DIFF
--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/sse/SseEmitters.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/sse/SseEmitters.java
@@ -30,23 +30,17 @@ public class SseEmitters {
 		final Long receiverId,
 		final Object data
 	) {
-		SseEmitter sseEmitter = get(receiverId);
+		SseEmitter sseEmitter = emitters.get(receiverId);
+		if (sseEmitter == null) {
+			log.warn("SSE를 구독하지 않은 유저입니다. userId : {}", receiverId);
+			return;
+		}
+
 		try {
 			sseEmitter.send(data);
 			log.info("알람을 보냈습니다. userId : {}", receiverId);
 		} catch (Exception e) {
-			log.error("알람을 보내는 과정에서 오류가 발생했습니다.");
-			throw new RuntimeException();
+			log.warn("알람을 보내는 과정에서 오류가 발생했습니다.");
 		}
-	}
-
-	public SseEmitter get(
-		final Long receiverId
-	) {
-		var sseEmitter = emitters.get(receiverId);
-		if (sseEmitter == null) {
-			log.warn("SSE를 구독하지 않은 유저입니다. userId : {}", receiverId);
-		}
-		return sseEmitter;
 	}
 }

--- a/bucketback-api/src/test/java/com/programmers/bucketback/domains/sse/SseEmittersTest.java
+++ b/bucketback-api/src/test/java/com/programmers/bucketback/domains/sse/SseEmittersTest.java
@@ -1,9 +1,12 @@
 package com.programmers.bucketback.domains.sse;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 class SseEmittersTest {
@@ -11,6 +14,7 @@ class SseEmittersTest {
 	SseEmitters sseEmitters = new SseEmitters();
 	Long memberId = 1L;
 	Long defaultTimeOut = 30 * 60 * 1000L;
+	Logger mockLogger = mock(Logger.class);
 
 	@Test
 	@DisplayName("새로운 Emitters를 추가에 성공한다.")
@@ -23,23 +27,20 @@ class SseEmittersTest {
 	}
 
 	@Test
-	@DisplayName("Emitters에 있는 정보를 가져올 수 있다.")
+	@DisplayName("Emitters에 정보가 존재한다.")
 	public void successGetEmitter() throws Exception {
 		//when
 		sseEmitters.add(memberId);
-		SseEmitter sseEmitter = sseEmitters.get(memberId);
 
 		//then
-		assertThat(sseEmitter).isNotNull();
+		verify(mockLogger, times(1));
+		assertDoesNotThrow(() -> sseEmitters.send(memberId, null));
 	}
 
 	@Test
 	@DisplayName("Emitters에 저장된 정보가 없다.")
 	public void failGetEmitter() throws Exception {
-		//when
-		SseEmitter sseEmitter = sseEmitters.get(memberId);
-
-		//then
-		assertThat(sseEmitter).isNull();
+		verify(mockLogger, times(1));
+		assertDoesNotThrow(() -> sseEmitters.send(memberId, null));
 	}
 }


### PR DESCRIPTION
## 📌 PR 종류

어떤 종류의 PR인지 아래 항목 중에 체크 해주세요.
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [ ]  🐛 버그 수정
- [ ]  ✨ 기능 추가
- [ ]  **✅** 테스트 추가
- [ ]  🎨 코드 스타일 변경 (formatting, local variables)
- [x]  🔨 리팩토링 (기능 변경 X)
- [ ]  **💚** 빌드 관련 수정
- [ ]  **📝** 문서 내용 수정
- [ ]  그 외, 어떤 종류인지 기입 바람:
<br>

## 📌 어떤 기능이 추가 되었나요?

<!--어떤 기능이 추가 되었는지 설명해주시고 관련된 지라 이슈 넘버를 추가 해주세요 -->

### Issue Number

408

### 기능 설명

댓글을 달면 알림을 수신받는 유저가 로그인되어있지 않은 경우 알림을 보내면 NPE 발생(500에러 응답)
그럼에도 불구하고 댓글을 달면 저장은 되고있어 비즈니스에는 영향을 주지 않기 때문에 200성공메세지로 전달하도록 수정함

차후 보완 포인트 : 이런 이벤트에 대한 알림을 지연시켜두었다가 다시 발송하는 이벤트 기반 처리 로직이 있으면 좋을 것 같음
https://techblog.woowahan.com/7835/
<br>

## 📌 기존에 있던 기능에 영향을 주나요?

- [ ]  네
- [ ]  아니요

<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->
