### PR TITLE
[OMCT-408] emitter 생명주기를 짧게 수정함, securityConfiguration에 subscribe 예외 처리

### DIFF
--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/sse/SseEmitters.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/sse/SseEmitters.java
@@ -12,16 +12,18 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 public class SseEmitters {
 
-	private static final Long DEFAULT_TIMEOUT = 30 * 60 * 1000L; // 60분
+	private static final Long DEFAULT_TIMEOUT = 10 * 1000L; //
 	private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
 
 	public SseEmitter add(final Long receiverId) {
 		SseEmitter sseEmitter = new SseEmitter(DEFAULT_TIMEOUT);
-
 		this.emitters.put(receiverId, sseEmitter);
 		sseEmitter.onTimeout(sseEmitter::complete);
 		sseEmitter.onCompletion(() -> this.emitters.remove(receiverId));
-		sseEmitter.onError((e) -> this.emitters.remove(receiverId));
+		sseEmitter.onError((e) -> {
+			log.error("error with emitter");
+			this.emitters.remove(receiverId);
+		});
 
 		return sseEmitter;
 	}

--- a/bucketback-api/src/main/java/com/programmers/bucketback/domains/sse/SseEmitters.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/domains/sse/SseEmitters.java
@@ -12,7 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 public class SseEmitters {
 
-	private static final Long DEFAULT_TIMEOUT = 10 * 1000L; //
+	private static final Long DEFAULT_TIMEOUT = 25 * 1000L; //25초
 	private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
 
 	public SseEmitter add(final Long receiverId) {

--- a/bucketback-api/src/main/java/com/programmers/bucketback/global/config/security/SecurityConfiguration.java
+++ b/bucketback-api/src/main/java/com/programmers/bucketback/global/config/security/SecurityConfiguration.java
@@ -63,6 +63,7 @@ public class SecurityConfiguration {
 					.requestMatchers("/api/{nickname}/buckets/**").permitAll()
 
 					.requestMatchers("/api/hobbies").permitAll()
+					.requestMatchers("/api/sse/subscribe").permitAll()
 
 					.anyRequest().authenticated()
 			)


### PR DESCRIPTION
## 📌 PR 종류

어떤 종류의 PR인지 아래 항목 중에 체크 해주세요.
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [x]  🐛 버그 수정
- [ ]  ✨ 기능 추가
- [ ]  **✅** 테스트 추가
- [ ]  🎨 코드 스타일 변경 (formatting, local variables)
- [ ]  🔨 리팩토링 (기능 변경 X)
- [ ]  **💚** 빌드 관련 수정
- [ ]  **📝** 문서 내용 수정
- [ ]  그 외, 어떤 종류인지 기입 바람:
<br>

## 📌 어떤 기능이 추가 되었나요?

<!--어떤 기능이 추가 되었는지 설명해주시고 관련된 지라 이슈 넘버를 추가 해주세요 -->

### Issue Number

408

### 기능 설명

- sseEmitter의 생명주기가 길면, 그만큼의 http 커넥션과 db 커넥션을 물고 있게됨(osivTrue상황)
- 그래서 이 생명주기를 짧게 유지하고, 재요청을 보내는 방식으로 emitter의 생명주기를 짧게 만듦
- but security 관련 문제가 발생함

**이유**
emitter가 timeOut의 콜백으로 스레드를 반환하면, 시큐리티의 생명 주기도 영향을 받는다.
시큐리티도 스레드와 생명주기가 같아서, 스레드를 반환하고 재할당을 받으면 그떄 securityContext는 존재하지 않아 accessDenied 예외를 맞게 된다.
emitter내의 예외는 아니기 때문에 emitter에서 콜백으로 감지하는 error도 발생하지 않고 나머지 기능들도 정상 작동하는걸 보면, 시큐리티 관련한 문제로 폭을 좁혀볼 수 있었다.

정리 : subscribe의 커넥션이 emitter의 생명 주기가 되면 종료된다. 그리고 바로 재요청을 보내서 새로운 스레드를 할당받는데, 이떄는 securitycontext를 새로 가질 수 없어 accessDenied가 발생한다.

해결 : subscribe api를 사요할 떄 securityconfiguration에 필터를 거치지 않도록 수정하여 예외없이 정상적인 종료를 하도록 수정함.

<br>

## 📌 기존에 있던 기능에 영향을 주나요?

- [x]  네
- [ ]  아니요

<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->
